### PR TITLE
Replaced double colon with underscore in workflow and activity names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,8 @@ googleJavaFormat {
 }
 
 group = 'io.temporal'
-version = '1.0.0'
+version = '0.10.0-SNAPSHOT'
+archivesBaseName="temporal-sdk"
 
 description = '''Temporal Workflow Java SDK'''
 
@@ -182,62 +183,62 @@ artifacts {
 def ossrhUsername = hasProperty('ossrhUsername') ? property('ossrhUsername') : ''
 def ossrhPassword = hasProperty('ossrhPassword') ? property('ossrhPassword') : ''
 
-publishing {
-
-    publications {
-        maven(MavenPublication) {
-            pom.withXml {
-                asNode().with {
-                    appendNode('packaging', 'jar')
-                    appendNode('name', 'temporal-sdk')
-                    appendNode('description', description)
-                    appendNode('url', 'https://github.com/temporalio/temporal-java-sdk')
-                    appendNode('scm').with {
-                        appendNode('url', 'https://github.com/temporalio/temporal-java-sdk')
-                        appendNode('connection', 'git@github.com:temporalio/temporal-java-sdk.git')
-                    }
-                    appendNode('licenses').with {
-                        appendNode('license').with {
-                            appendNode('name', 'The Apache License, Version 2.0')
-                            appendNode('url', 'http://www.apache.org/licenses/LICENSE-2.0.txt')
-                        }
-                    }
-                    appendNode('developers').with {
-                        appendNode('maxim').with {
-                            appendNode('id', 'mfateev')
-                            appendNode('name', 'Maxim Fateev')
-                            appendNode('email', 'maxim@temporal.io')
-                        }
-                        appendNode('developer').with {
-                            appendNode('id', 'samarabbas')
-                            appendNode('name', 'Samar Abbas')
-                            appendNode('email', 'samar@temporal.io')
-                        }
-                    }
-                }
-            }
-        }
-
-        mavenJava(MavenPublication) {
-            from components.java
-            artifact javadocJar
-            artifact sourcesJar
-        }
-    }
-    repositories {
-        maven {
-            credentials {
-                username ossrhUsername
-                password ossrhPassword
-            }
-            if (project.version.endsWith('-SNAPSHOT')) {
-                url 'https://oss.sonatype.org/content/repositories/snapshots/'
-            } else {
-                url 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-            }
-        }
-    }
-}
+//publishing {
+//
+//    publications {
+//        maven(MavenPublication) {
+//            pom.withXml {
+//                asNode().with {
+//                    appendNode('packaging', 'jar')
+//                    appendNode('name', 'temporal-sdk')
+//                    appendNode('description', description)
+//                    appendNode('url', 'https://github.com/temporalio/temporal-java-sdk')
+//                    appendNode('scm').with {
+//                        appendNode('url', 'https://github.com/temporalio/temporal-java-sdk')
+//                        appendNode('connection', 'git@github.com:temporalio/temporal-java-sdk.git')
+//                    }
+//                    appendNode('licenses').with {
+//                        appendNode('license').with {
+//                            appendNode('name', 'The Apache License, Version 2.0')
+//                            appendNode('url', 'http://www.apache.org/licenses/LICENSE-2.0.txt')
+//                        }
+//                    }
+//                    appendNode('developers').with {
+//                        appendNode('maxim').with {
+//                            appendNode('id', 'mfateev')
+//                            appendNode('name', 'Maxim Fateev')
+//                            appendNode('email', 'maxim@temporal.io')
+//                        }
+//                        appendNode('developer').with {
+//                            appendNode('id', 'samarabbas')
+//                            appendNode('name', 'Samar Abbas')
+//                            appendNode('email', 'samar@temporal.io')
+//                        }
+//                    }
+//                }
+//            }
+//        }
+//
+//        mavenJava(MavenPublication) {
+//            from components.java
+//            artifact javadocJar
+//            artifact sourcesJar
+//        }
+//    }
+//    repositories {
+//        maven {
+//            credentials {
+//                username ossrhUsername
+//                password ossrhPassword
+//            }
+//            if (project.version.endsWith('-SNAPSHOT')) {
+//                url 'https://oss.sonatype.org/content/repositories/snapshots/'
+//            } else {
+//                url 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+//            }
+//        }
+//    }
+//}
 
 task registerDomain(type: JavaExec) {
     main = 'io.temporal.RegisterTestDomain'
@@ -269,10 +270,10 @@ uploadArchives {
             }
 
             pom.project {
-                name 'temporal-sdk'
+                name 'Temporal Java SDK'
                 packaging 'jar'
                 // optionally artifactId can be defined here
-                description 'Temporal Java SDK'
+                description 'Temporal Workflow Java SDK'
                 url 'https://github.com/temporalio/temporal-java-sdk'
 
                 scm {

--- a/build.gradle
+++ b/build.gradle
@@ -183,63 +183,6 @@ artifacts {
 def ossrhUsername = hasProperty('ossrhUsername') ? property('ossrhUsername') : ''
 def ossrhPassword = hasProperty('ossrhPassword') ? property('ossrhPassword') : ''
 
-//publishing {
-//
-//    publications {
-//        maven(MavenPublication) {
-//            pom.withXml {
-//                asNode().with {
-//                    appendNode('packaging', 'jar')
-//                    appendNode('name', 'temporal-sdk')
-//                    appendNode('description', description)
-//                    appendNode('url', 'https://github.com/temporalio/temporal-java-sdk')
-//                    appendNode('scm').with {
-//                        appendNode('url', 'https://github.com/temporalio/temporal-java-sdk')
-//                        appendNode('connection', 'git@github.com:temporalio/temporal-java-sdk.git')
-//                    }
-//                    appendNode('licenses').with {
-//                        appendNode('license').with {
-//                            appendNode('name', 'The Apache License, Version 2.0')
-//                            appendNode('url', 'http://www.apache.org/licenses/LICENSE-2.0.txt')
-//                        }
-//                    }
-//                    appendNode('developers').with {
-//                        appendNode('maxim').with {
-//                            appendNode('id', 'mfateev')
-//                            appendNode('name', 'Maxim Fateev')
-//                            appendNode('email', 'maxim@temporal.io')
-//                        }
-//                        appendNode('developer').with {
-//                            appendNode('id', 'samarabbas')
-//                            appendNode('name', 'Samar Abbas')
-//                            appendNode('email', 'samar@temporal.io')
-//                        }
-//                    }
-//                }
-//            }
-//        }
-//
-//        mavenJava(MavenPublication) {
-//            from components.java
-//            artifact javadocJar
-//            artifact sourcesJar
-//        }
-//    }
-//    repositories {
-//        maven {
-//            credentials {
-//                username ossrhUsername
-//                password ossrhPassword
-//            }
-//            if (project.version.endsWith('-SNAPSHOT')) {
-//                url 'https://oss.sonatype.org/content/repositories/snapshots/'
-//            } else {
-//                url 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-//            }
-//        }
-//    }
-//}
-
 task registerDomain(type: JavaExec) {
     main = 'io.temporal.RegisterTestDomain'
     classpath = sourceSets.test.runtimeClasspath

--- a/src/main/java/io/temporal/internal/common/InternalUtils.java
+++ b/src/main/java/io/temporal/internal/common/InternalUtils.java
@@ -40,10 +40,10 @@ public final class InternalUtils {
   /**
    * Used to construct default name of an activity or workflow type from a method it implements.
    *
-   * @return "Simple class name"::"methodName"
+   * @return "Simple class name"_"methodName"
    */
   public static String getSimpleName(Method method) {
-    return method.getDeclaringClass().getSimpleName() + "::" + method.getName();
+    return method.getDeclaringClass().getSimpleName() + "_" + method.getName();
   }
 
   public static String getWorkflowType(Method method, WorkflowMethod workflowMethod) {

--- a/src/test/java/io/temporal/internal/testing/ActivityTestingTest.java
+++ b/src/test/java/io/temporal/internal/testing/ActivityTestingTest.java
@@ -62,7 +62,7 @@ public class ActivityTestingTest {
     testEnvironment.registerActivitiesImplementations(new ActivityImpl());
     TestActivity activity = testEnvironment.newActivityStub(TestActivity.class);
     String result = activity.activity1("input1");
-    assertEquals("TestActivity::activity1-input1", result);
+    assertEquals("TestActivity_activity1-input1", result);
   }
 
   private static class AngryActivityImpl implements TestActivity {
@@ -81,7 +81,7 @@ public class ActivityTestingTest {
       activity.activity1("input1");
       fail("unreachable");
     } catch (ActivityFailureException e) {
-      assertTrue(e.getMessage().contains("TestActivity::activity1"));
+      assertTrue(e.getMessage().contains("TestActivity_activity1"));
       assertTrue(e.getCause() instanceof IOException);
       assertEquals("simulated", e.getCause().getMessage());
     }

--- a/src/test/java/io/temporal/internal/testing/WorkflowTestingTest.java
+++ b/src/test/java/io/temporal/internal/testing/WorkflowTestingTest.java
@@ -136,7 +136,7 @@ public class WorkflowTestingTest {
     WorkflowClient client = testEnvironment.getWorkflowClient();
     TestWorkflow workflow = client.newWorkflowStub(TestWorkflow.class);
     String result = workflow.workflow1("input1");
-    assertEquals("TestWorkflow::workflow1-input1", result);
+    assertEquals("TestWorkflow_workflow1-input1", result);
   }
 
   public static class FailingWorkflowImpl implements TestWorkflow {
@@ -161,7 +161,7 @@ public class WorkflowTestingTest {
       workflow.workflow1("input1");
       fail("unreacheable");
     } catch (WorkflowException e) {
-      assertEquals("TestWorkflow::workflow1-input1", e.getCause().getMessage());
+      assertEquals("TestWorkflow_workflow1-input1", e.getCause().getMessage());
     }
   }
 
@@ -199,7 +199,7 @@ public class WorkflowTestingTest {
     WorkflowClient client = testEnvironment.getWorkflowClient();
     TestWorkflow workflow = client.newWorkflowStub(TestWorkflow.class);
     String result = workflow.workflow1("input1");
-    assertEquals("TestActivity::activity1-input1", result);
+    assertEquals("TestActivity_activity1-input1", result);
   }
 
   private static class FailingActivityImpl implements TestActivity {
@@ -222,7 +222,7 @@ public class WorkflowTestingTest {
       workflow.workflow1("input1");
       fail("unreacheable");
     } catch (WorkflowException e) {
-      assertEquals("TestActivity::activity1-input1", e.getCause().getCause().getMessage());
+      assertEquals("TestActivity_activity1-input1", e.getCause().getCause().getMessage());
     }
   }
 
@@ -397,7 +397,7 @@ public class WorkflowTestingTest {
     TestWorkflow workflow = client.newWorkflowStub(TestWorkflow.class);
     long start = testEnvironment.currentTimeMillis();
     String result = workflow.workflow1("input1");
-    assertEquals("TestWorkflow::workflow1-input1", result);
+    assertEquals("TestWorkflow_workflow1-input1", result);
     assertTrue(testEnvironment.currentTimeMillis() - start >= Duration.ofHours(2).toMillis());
   }
 
@@ -697,12 +697,10 @@ public class WorkflowTestingTest {
       assertEquals(2, executions.size());
       String name0 = executions.get(0).getType().getName();
       assertTrue(
-          name0,
-          name0.equals("ParentWorkflow::workflow") || name0.equals("ChildWorkflow::workflow"));
+          name0, name0.equals("ParentWorkflow_workflow") || name0.equals("ChildWorkflow_workflow"));
       String name1 = executions.get(0).getType().getName();
       assertTrue(
-          name1,
-          name1.equals("ParentWorkflow::workflow") || name1.equals("ChildWorkflow::workflow"));
+          name1, name1.equals("ParentWorkflow_workflow") || name1.equals("ChildWorkflow_workflow"));
 
       try {
         result.get();
@@ -727,10 +725,10 @@ public class WorkflowTestingTest {
     assertEquals(2, executions.size());
     String name0 = executions.get(0).getType().getName();
     assertTrue(
-        name0, name0.equals("ParentWorkflow::workflow") || name0.equals("ChildWorkflow::workflow"));
+        name0, name0.equals("ParentWorkflow_workflow") || name0.equals("ChildWorkflow_workflow"));
     String name1 = executions.get(0).getType().getName();
     assertTrue(
-        name1, name1.equals("ParentWorkflow::workflow") || name1.equals("ChildWorkflow::workflow"));
+        name1, name1.equals("ParentWorkflow_workflow") || name1.equals("ChildWorkflow_workflow"));
   }
 
   @Test

--- a/src/test/java/io/temporal/worker/WorkerStressTests.java
+++ b/src/test/java/io/temporal/worker/WorkerStressTests.java
@@ -100,7 +100,7 @@ public class WorkerStressTests {
     WorkflowStub workflow =
         wrapper
             .getWorkflowClient()
-            .newUntypedWorkflowStub("ActivitiesWorkflow::execute", workflowOptions);
+            .newUntypedWorkflowStub("ActivitiesWorkflow_execute", workflowOptions);
 
     // Act
     // This will yeild around 10000 events which is above the page limit returned by the server.
@@ -141,7 +141,7 @@ public class WorkerStressTests {
     WorkflowStub workflow =
         wrapper
             .getWorkflowClient()
-            .newUntypedWorkflowStub("ActivitiesWorkflow::execute", workflowOptions);
+            .newUntypedWorkflowStub("ActivitiesWorkflow_execute", workflowOptions);
 
     // Act
     WorkflowParams w = new WorkflowParams();
@@ -161,7 +161,7 @@ public class WorkerStressTests {
     WorkflowStub workflow2 =
         wrapper
             .getWorkflowClient()
-            .newUntypedWorkflowStub("ActivitiesWorkflow::execute", workflowOptions);
+            .newUntypedWorkflowStub("ActivitiesWorkflow_execute", workflowOptions);
     w.ConcurrentCount = 1;
     workflow2.start(w);
     assertNotNull("I'm done.", workflow2.getResult(String.class));

--- a/src/test/java/io/temporal/workflow/MetricsTest.java
+++ b/src/test/java/io/temporal/workflow/MetricsTest.java
@@ -261,8 +261,8 @@ public class MetricsTest {
         new ImmutableMap.Builder<String, String>(3)
             .put(MetricsTag.DOMAIN, WorkflowTest.DOMAIN)
             .put(MetricsTag.TASK_LIST, taskList)
-            .put(MetricsTag.ACTIVITY_TYPE, "TestActivity::runActivity")
-            .put(MetricsTag.WORKFLOW_TYPE, "TestWorkflow::execute")
+            .put(MetricsTag.ACTIVITY_TYPE, "TestActivity_runActivity")
+            .put(MetricsTag.WORKFLOW_TYPE, "TestWorkflow_execute")
             .build();
     verify(reporter, times(1))
         .reportCounter("temporal-activity-task-completed", activityCompletionTags, 1);

--- a/src/test/java/io/temporal/workflow/WorkflowTest.java
+++ b/src/test/java/io/temporal/workflow/WorkflowTest.java
@@ -415,8 +415,8 @@ public class WorkflowTest {
     assertEquals("activity10", result);
     tracer.setExpected(
         "sleep PT2S",
-        "executeActivity TestActivities::activityWithDelay",
-        "executeActivity TestActivities::activity2");
+        "executeActivity TestActivities_activityWithDelay",
+        "executeActivity TestActivities_activity2");
   }
 
   public static class TestActivityRetryWithMaxAttempts implements TestWorkflow1 {
@@ -678,7 +678,7 @@ public class WorkflowTest {
                       .build())
               .build();
       ActivityStub activities = Workflow.newUntypedActivityStub(options);
-      activities.execute("TestActivities::throwIO", Void.class);
+      activities.execute("TestActivities_throwIO", Void.class);
       return "ignored";
     }
   }
@@ -889,7 +889,7 @@ public class WorkflowTest {
     startWorkerFor(TestSyncWorkflowImpl.class);
     WorkflowStub workflowStub =
         workflowClient.newUntypedWorkflowStub(
-            "TestWorkflow1::execute", newWorkflowOptionsBuilder(taskList).build());
+            "TestWorkflow1_execute", newWorkflowOptionsBuilder(taskList).build());
     WorkflowExecution execution = workflowStub.start(taskList);
     sleep(Duration.ofMillis(500));
     String stackTrace = workflowStub.query(WorkflowClient.QUERY_TYPE_STACK_TRACE, String.class);
@@ -927,7 +927,7 @@ public class WorkflowTest {
     startWorkerFor(TestCancellationForWorkflowsWithFailedPromises.class);
     WorkflowStub client =
         workflowClient.newUntypedWorkflowStub(
-            "TestWorkflow1::execute", newWorkflowOptionsBuilder(taskList).build());
+            "TestWorkflow1_execute", newWorkflowOptionsBuilder(taskList).build());
     client.start(taskList);
     client.cancel();
 
@@ -943,7 +943,7 @@ public class WorkflowTest {
     startWorkerFor(TestSyncWorkflowImpl.class);
     WorkflowStub client =
         workflowClient.newUntypedWorkflowStub(
-            "TestWorkflow1::execute", newWorkflowOptionsBuilder(taskList).build());
+            "TestWorkflow1_execute", newWorkflowOptionsBuilder(taskList).build());
     client.start(taskList);
     client.cancel();
     try {
@@ -968,7 +968,7 @@ public class WorkflowTest {
     startWorkerFor(TestCancellationScopePromise.class);
     WorkflowStub client =
         workflowClient.newUntypedWorkflowStub(
-            "TestWorkflow1::execute", newWorkflowOptionsBuilder(taskList).build());
+            "TestWorkflow1_execute", newWorkflowOptionsBuilder(taskList).build());
     client.start(taskList);
     client.cancel();
     try {
@@ -1018,7 +1018,7 @@ public class WorkflowTest {
     startWorkerFor(TestDetachedCancellationScope.class);
     WorkflowStub client =
         workflowClient.newUntypedWorkflowStub(
-            "TestWorkflow1::execute", newWorkflowOptionsBuilder(taskList).build());
+            "TestWorkflow1_execute", newWorkflowOptionsBuilder(taskList).build());
     client.start(taskList);
     sleep(Duration.ofMillis(500)); // To let activityWithDelay start.
     client.cancel();
@@ -1135,7 +1135,7 @@ public class WorkflowTest {
     public String execute(String taskList) {
       ActivityStub testActivities = Workflow.newUntypedActivityStub(newActivityOptions2());
       Promise<String> a =
-          Async.function(testActivities::<String>execute, "TestActivities::activity", String.class);
+          Async.function(testActivities::<String>execute, "TestActivities_activity", String.class);
       Promise<String> a1 =
           Async.function(
               testActivities::<String>execute,
@@ -1144,19 +1144,14 @@ public class WorkflowTest {
               "1"); // name overridden in annotation
       Promise<String> a2 =
           Async.function(
-              testActivities::<String>execute, "TestActivities::activity2", String.class, "1", 2);
+              testActivities::<String>execute, "TestActivities_activity2", String.class, "1", 2);
       Promise<String> a3 =
           Async.function(
-              testActivities::<String>execute,
-              "TestActivities::activity3",
-              String.class,
-              "1",
-              2,
-              3);
+              testActivities::<String>execute, "TestActivities_activity3", String.class, "1", 2, 3);
       Promise<String> a4 =
           Async.function(
               testActivities::<String>execute,
-              "TestActivities::activity4",
+              "TestActivities_activity4",
               String.class,
               "1",
               2,
@@ -1168,15 +1163,14 @@ public class WorkflowTest {
       assertEquals("123", a3.get());
       assertEquals("1234", a4.get());
 
-      Async.procedure(testActivities::<Void>execute, "TestActivities::proc", Void.class).get();
-      Async.procedure(testActivities::<Void>execute, "TestActivities::proc1", Void.class, "1")
+      Async.procedure(testActivities::<Void>execute, "TestActivities_proc", Void.class).get();
+      Async.procedure(testActivities::<Void>execute, "TestActivities_proc1", Void.class, "1").get();
+      Async.procedure(testActivities::<Void>execute, "TestActivities_proc2", Void.class, "1", 2)
           .get();
-      Async.procedure(testActivities::<Void>execute, "TestActivities::proc2", Void.class, "1", 2)
-          .get();
-      Async.procedure(testActivities::<Void>execute, "TestActivities::proc3", Void.class, "1", 2, 3)
+      Async.procedure(testActivities::<Void>execute, "TestActivities_proc3", Void.class, "1", 2, 3)
           .get();
       Async.procedure(
-              testActivities::<Void>execute, "TestActivities::proc4", Void.class, "1", 2, 3, 4)
+              testActivities::<Void>execute, "TestActivities_proc4", Void.class, "1", 2, 3, 4)
           .get();
       return "workflow";
     }
@@ -1202,21 +1196,20 @@ public class WorkflowTest {
     @Override
     public String execute(String taskList) {
       ActivityStub testActivities = Workflow.newUntypedActivityStub(newActivityOptions2());
-      Promise<String> a = testActivities.executeAsync("TestActivities::activity", String.class);
+      Promise<String> a = testActivities.executeAsync("TestActivities_activity", String.class);
       Promise<String> a1 =
           testActivities.executeAsync(
               "customActivity1", String.class, "1"); // name overridden in annotation
       Promise<String> a2 =
-          testActivities.executeAsync("TestActivities::activity2", String.class, "1", 2);
+          testActivities.executeAsync("TestActivities_activity2", String.class, "1", 2);
       Promise<String> a3 =
-          testActivities.executeAsync("TestActivities::activity3", String.class, "1", 2, 3);
+          testActivities.executeAsync("TestActivities_activity3", String.class, "1", 2, 3);
       Promise<String> a4 =
-          testActivities.executeAsync("TestActivities::activity4", String.class, "1", 2, 3, 4);
+          testActivities.executeAsync("TestActivities_activity4", String.class, "1", 2, 3, 4);
       Promise<String> a5 =
-          testActivities.executeAsync("TestActivities::activity5", String.class, "1", 2, 3, 4, 5);
+          testActivities.executeAsync("TestActivities_activity5", String.class, "1", 2, 3, 4, 5);
       Promise<String> a6 =
-          testActivities.executeAsync(
-              "TestActivities::activity6", String.class, "1", 2, 3, 4, 5, 6);
+          testActivities.executeAsync("TestActivities_activity6", String.class, "1", 2, 3, 4, 5, 6);
       assertEquals("activity", a.get());
       assertEquals("1", a1.get());
       assertEquals("12", a2.get());
@@ -1225,13 +1218,13 @@ public class WorkflowTest {
       assertEquals("12345", a5.get());
       assertEquals("123456", a6.get());
 
-      testActivities.executeAsync("TestActivities::proc", Void.class).get();
-      testActivities.executeAsync("TestActivities::proc1", Void.class, "1").get();
-      testActivities.executeAsync("TestActivities::proc2", Void.class, "1", 2).get();
-      testActivities.executeAsync("TestActivities::proc3", Void.class, "1", 2, 3).get();
-      testActivities.executeAsync("TestActivities::proc4", Void.class, "1", 2, 3, 4).get();
-      testActivities.executeAsync("TestActivities::proc5", Void.class, "1", 2, 3, 4, 5).get();
-      testActivities.executeAsync("TestActivities::proc6", Void.class, "1", 2, 3, 4, 5, 6).get();
+      testActivities.executeAsync("TestActivities_proc", Void.class).get();
+      testActivities.executeAsync("TestActivities_proc1", Void.class, "1").get();
+      testActivities.executeAsync("TestActivities_proc2", Void.class, "1", 2).get();
+      testActivities.executeAsync("TestActivities_proc3", Void.class, "1", 2, 3).get();
+      testActivities.executeAsync("TestActivities_proc4", Void.class, "1", 2, 3, 4).get();
+      testActivities.executeAsync("TestActivities_proc5", Void.class, "1", 2, 3, 4, 5).get();
+      testActivities.executeAsync("TestActivities_proc6", Void.class, "1", 2, 3, 4, 5, 6).get();
       return "workflow";
     }
   }
@@ -1662,58 +1655,58 @@ public class WorkflowTest {
       ChildWorkflowOptions workflowOptions =
           ChildWorkflowOptions.newBuilder().setTaskList(taskList).build();
       ChildWorkflowStub stubF =
-          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc::func", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc_func", workflowOptions);
       assertEquals("func", stubF.execute(String.class));
       // Workflow type overridden through the @WorkflowMethod.name
       ChildWorkflowStub stubF1 = Workflow.newUntypedChildWorkflowStub("func1", workflowOptions);
       assertEquals("1", stubF1.execute(String.class, "1"));
       ChildWorkflowStub stubF2 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc2::func2", workflowOptions);
+              "TestMultiargsWorkflowsFunc2_func2", workflowOptions);
       assertEquals("12", stubF2.execute(String.class, "1", 2));
       ChildWorkflowStub stubF3 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc3::func3", workflowOptions);
+              "TestMultiargsWorkflowsFunc3_func3", workflowOptions);
       assertEquals("123", stubF3.execute(String.class, "1", 2, 3));
       ChildWorkflowStub stubF4 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc4::func4", workflowOptions);
+              "TestMultiargsWorkflowsFunc4_func4", workflowOptions);
       assertEquals("1234", stubF4.execute(String.class, "1", 2, 3, 4));
       ChildWorkflowStub stubF5 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc5::func5", workflowOptions);
+              "TestMultiargsWorkflowsFunc5_func5", workflowOptions);
       assertEquals("12345", stubF5.execute(String.class, "1", 2, 3, 4, 5));
       ChildWorkflowStub stubF6 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc6::func6", workflowOptions);
+              "TestMultiargsWorkflowsFunc6_func6", workflowOptions);
       assertEquals("123456", stubF6.execute(String.class, "1", 2, 3, 4, 5, 6));
 
       ChildWorkflowStub stubP =
-          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc::proc", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc_proc", workflowOptions);
       stubP.execute(Void.class);
       ChildWorkflowStub stubP1 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc1::proc1", workflowOptions);
+              "TestMultiargsWorkflowsProc1_proc1", workflowOptions);
       stubP1.execute(Void.class, "1");
       ChildWorkflowStub stubP2 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc2::proc2", workflowOptions);
+              "TestMultiargsWorkflowsProc2_proc2", workflowOptions);
       stubP2.execute(Void.class, "1", 2);
       ChildWorkflowStub stubP3 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc3::proc3", workflowOptions);
+              "TestMultiargsWorkflowsProc3_proc3", workflowOptions);
       stubP3.execute(Void.class, "1", 2, 3);
       ChildWorkflowStub stubP4 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc4::proc4", workflowOptions);
+              "TestMultiargsWorkflowsProc4_proc4", workflowOptions);
       stubP4.execute(Void.class, "1", 2, 3, 4);
       ChildWorkflowStub stubP5 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc5::proc5", workflowOptions);
+              "TestMultiargsWorkflowsProc5_proc5", workflowOptions);
       stubP5.execute(Void.class, "1", 2, 3, 4, 5);
       ChildWorkflowStub stubP6 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc6::proc6", workflowOptions);
+              "TestMultiargsWorkflowsProc6_proc6", workflowOptions);
       stubP6.execute(Void.class, "1", 2, 3, 4, 5, 6);
       return null;
     }
@@ -1738,58 +1731,58 @@ public class WorkflowTest {
       ChildWorkflowOptions workflowOptions =
           ChildWorkflowOptions.newBuilder().setTaskList(taskList).build();
       ChildWorkflowStub stubF =
-          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc::func", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc_func", workflowOptions);
       assertEquals("func", stubF.executeAsync(String.class).get());
       // Workflow type overridden through the @WorkflowMethod.name
       ChildWorkflowStub stubF1 = Workflow.newUntypedChildWorkflowStub("func1", workflowOptions);
       assertEquals("1", stubF1.executeAsync(String.class, "1").get());
       ChildWorkflowStub stubF2 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc2::func2", workflowOptions);
+              "TestMultiargsWorkflowsFunc2_func2", workflowOptions);
       assertEquals("12", stubF2.executeAsync(String.class, "1", 2).get());
       ChildWorkflowStub stubF3 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc3::func3", workflowOptions);
+              "TestMultiargsWorkflowsFunc3_func3", workflowOptions);
       assertEquals("123", stubF3.executeAsync(String.class, "1", 2, 3).get());
       ChildWorkflowStub stubF4 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc4::func4", workflowOptions);
+              "TestMultiargsWorkflowsFunc4_func4", workflowOptions);
       assertEquals("1234", stubF4.executeAsync(String.class, "1", 2, 3, 4).get());
       ChildWorkflowStub stubF5 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc5::func5", workflowOptions);
+              "TestMultiargsWorkflowsFunc5_func5", workflowOptions);
       assertEquals("12345", stubF5.executeAsync(String.class, "1", 2, 3, 4, 5).get());
       ChildWorkflowStub stubF6 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc6::func6", workflowOptions);
+              "TestMultiargsWorkflowsFunc6_func6", workflowOptions);
       assertEquals("123456", stubF6.executeAsync(String.class, "1", 2, 3, 4, 5, 6).get());
 
       ChildWorkflowStub stubP =
-          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc::proc", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc_proc", workflowOptions);
       stubP.executeAsync(Void.class).get();
       ChildWorkflowStub stubP1 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc1::proc1", workflowOptions);
+              "TestMultiargsWorkflowsProc1_proc1", workflowOptions);
       stubP1.executeAsync(Void.class, "1").get();
       ChildWorkflowStub stubP2 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc2::proc2", workflowOptions);
+              "TestMultiargsWorkflowsProc2_proc2", workflowOptions);
       stubP2.executeAsync(Void.class, "1", 2).get();
       ChildWorkflowStub stubP3 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc3::proc3", workflowOptions);
+              "TestMultiargsWorkflowsProc3_proc3", workflowOptions);
       stubP3.executeAsync(Void.class, "1", 2, 3).get();
       ChildWorkflowStub stubP4 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc4::proc4", workflowOptions);
+              "TestMultiargsWorkflowsProc4_proc4", workflowOptions);
       stubP4.executeAsync(Void.class, "1", 2, 3, 4).get();
       ChildWorkflowStub stubP5 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc5::proc5", workflowOptions);
+              "TestMultiargsWorkflowsProc5_proc5", workflowOptions);
       stubP5.executeAsync(Void.class, "1", 2, 3, 4, 5).get();
       ChildWorkflowStub stubP6 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc6::proc6", workflowOptions);
+              "TestMultiargsWorkflowsProc6_proc6", workflowOptions);
       stubP6.executeAsync(Void.class, "1", 2, 3, 4, 5, 6).get();
       return null;
     }
@@ -1814,52 +1807,52 @@ public class WorkflowTest {
       ChildWorkflowOptions workflowOptions =
           ChildWorkflowOptions.newBuilder().setTaskList(taskList).build();
       ChildWorkflowStub stubF =
-          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc::func", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc_func", workflowOptions);
       assertEquals("func", Async.function(stubF::<String>execute, String.class).get());
       // Workflow type overridden through the @WorkflowMethod.name
       ChildWorkflowStub stubF1 = Workflow.newUntypedChildWorkflowStub("func1", workflowOptions);
       assertEquals("1", Async.function(stubF1::<String>execute, String.class, "1").get());
       ChildWorkflowStub stubF2 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc2::func2", workflowOptions);
+              "TestMultiargsWorkflowsFunc2_func2", workflowOptions);
       assertEquals("12", Async.function(stubF2::<String>execute, String.class, "1", 2).get());
       ChildWorkflowStub stubF3 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc3::func3", workflowOptions);
+              "TestMultiargsWorkflowsFunc3_func3", workflowOptions);
       assertEquals("123", Async.function(stubF3::<String>execute, String.class, "1", 2, 3).get());
       ChildWorkflowStub stubF4 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc4::func4", workflowOptions);
+              "TestMultiargsWorkflowsFunc4_func4", workflowOptions);
       assertEquals(
           "1234", Async.function(stubF4::<String>execute, String.class, "1", 2, 3, 4).get());
       ChildWorkflowStub stubF5 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc5::func5", workflowOptions);
+              "TestMultiargsWorkflowsFunc5_func5", workflowOptions);
       assertEquals(
           "12345", Async.function(stubF5::<String>execute, String.class, "1", 2, 3, 4, 5).get());
 
       ChildWorkflowStub stubP =
-          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc::proc", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc_proc", workflowOptions);
       Async.procedure(stubP::<Void>execute, Void.class).get();
       ChildWorkflowStub stubP1 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc1::proc1", workflowOptions);
+              "TestMultiargsWorkflowsProc1_proc1", workflowOptions);
       Async.procedure(stubP1::<Void>execute, Void.class, "1").get();
       ChildWorkflowStub stubP2 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc2::proc2", workflowOptions);
+              "TestMultiargsWorkflowsProc2_proc2", workflowOptions);
       Async.procedure(stubP2::<Void>execute, Void.class, "1", 2).get();
       ChildWorkflowStub stubP3 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc3::proc3", workflowOptions);
+              "TestMultiargsWorkflowsProc3_proc3", workflowOptions);
       Async.procedure(stubP3::<Void>execute, Void.class, "1", 2, 3).get();
       ChildWorkflowStub stubP4 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc4::proc4", workflowOptions);
+              "TestMultiargsWorkflowsProc4_proc4", workflowOptions);
       Async.procedure(stubP4::<Void>execute, Void.class, "1", 2, 3, 4).get();
       ChildWorkflowStub stubP5 =
           Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc5::proc5", workflowOptions);
+              "TestMultiargsWorkflowsProc5_proc5", workflowOptions);
       Async.procedure(stubP5::<Void>execute, Void.class, "1", 2, 3, 4, 5).get();
       return null;
     }
@@ -2088,7 +2081,7 @@ public class WorkflowTest {
         return "ignored";
       } catch (ActivityFailureException e) {
         try {
-          assertTrue(e.getMessage().contains("TestActivities::throwIO"));
+          assertTrue(e.getMessage().contains("TestActivities_throwIO"));
           assertTrue(e.getCause() instanceof IOException);
           assertEquals("simulated IO problem", e.getCause().getMessage());
         } catch (AssertionError ae) {
@@ -2118,7 +2111,7 @@ public class WorkflowTest {
       } catch (RuntimeException e) {
         try {
           assertNoEmptyStacks(e);
-          assertTrue(e.getMessage().contains("TestWorkflow1::execute"));
+          assertTrue(e.getMessage().contains("TestWorkflow1_execute"));
           assertTrue(e instanceof ChildWorkflowException);
           assertTrue(e.getCause() instanceof NumberFormatException);
           assertTrue(e.getCause().getCause() instanceof ActivityFailureException);
@@ -2176,7 +2169,7 @@ public class WorkflowTest {
       assertNoEmptyStacks(e);
       // Uncomment to see the actual trace.
       //            e.printStackTrace();
-      assertTrue(e.getMessage(), e.getMessage().contains("TestExceptionPropagation::execute"));
+      assertTrue(e.getMessage(), e.getMessage().contains("TestExceptionPropagation_execute"));
       assertTrue(e.getStackTrace().length > 0);
       assertTrue(e.getCause() instanceof FileNotFoundException);
       assertTrue(e.getCause().getCause() instanceof ChildWorkflowException);
@@ -2394,7 +2387,7 @@ public class WorkflowTest {
   @Test
   public void testSignalUntyped() {
     startWorkerFor(TestSignalWorkflowImpl.class);
-    String workflowType = QueryableWorkflow.class.getSimpleName() + "::execute";
+    String workflowType = QueryableWorkflow.class.getSimpleName() + "_execute";
     AtomicReference<WorkflowExecution> execution = new AtomicReference<>();
     WorkflowStub client =
         workflowClient.newUntypedWorkflowStub(
@@ -2404,14 +2397,14 @@ public class WorkflowTest {
     registerDelayedCallback(
         Duration.ofSeconds(1),
         () -> {
-          assertEquals("initial", client.query("QueryableWorkflow::getState", String.class));
+          assertEquals("initial", client.query("QueryableWorkflow_getState", String.class));
           client.signal("testSignal", "Hello ");
           sleep(Duration.ofMillis(500));
-          while (!"Hello ".equals(client.query("QueryableWorkflow::getState", String.class))) {}
-          assertEquals("Hello ", client.query("QueryableWorkflow::getState", String.class));
+          while (!"Hello ".equals(client.query("QueryableWorkflow_getState", String.class))) {}
+          assertEquals("Hello ", client.query("QueryableWorkflow_getState", String.class));
           client.signal("testSignal", "World!");
-          while (!"World!".equals(client.query("QueryableWorkflow::getState", String.class))) {}
-          assertEquals("World!", client.query("QueryableWorkflow::getState", String.class));
+          while (!"World!".equals(client.query("QueryableWorkflow_getState", String.class))) {}
+          assertEquals("World!", client.query("QueryableWorkflow_getState", String.class));
           assertEquals(
               "Hello World!",
               workflowClient
@@ -2420,10 +2413,10 @@ public class WorkflowTest {
         });
     execution.set(client.start());
     assertEquals("Hello World!", client.getResult(String.class));
-    assertEquals("World!", client.query("QueryableWorkflow::getState", String.class));
+    assertEquals("World!", client.query("QueryableWorkflow_getState", String.class));
     QueryResponse<String> queryResponse =
         client.query(
-            "QueryableWorkflow::getState",
+            "QueryableWorkflow_getState",
             String.class,
             QueryRejectCondition.QueryRejectConditionNotOpen);
     assertNull(queryResponse.getResult());
@@ -2840,7 +2833,7 @@ public class WorkflowTest {
       assertTrue(e.toString(), e.getCause().getCause() instanceof UnsupportedOperationException);
       assertEquals("simulated failure", e.getCause().getCause().getMessage());
     }
-    assertEquals("TestWorkflow1::execute", lastStartedWorkflowType.get());
+    assertEquals("TestWorkflow1_execute", lastStartedWorkflowType.get());
     assertEquals(3, angryChildActivity.getInvocationCount());
   }
 
@@ -2953,14 +2946,14 @@ public class WorkflowTest {
         workflowClient.newWorkflowStub(TestWorkflowSignaled.class, options);
     assertEquals("Hello World!", client.execute());
     tracer.setExpected(
-        "executeChildWorkflow SignalingChild::execute",
+        "executeChildWorkflow SignalingChild_execute",
         "signalExternalWorkflow " + UUID_REGEXP + " testSignal");
   }
 
   public static class TestUntypedSignalExternalWorkflow implements TestWorkflowSignaled {
 
     private final ChildWorkflowStub child =
-        Workflow.newUntypedChildWorkflowStub("SignalingChild::execute");
+        Workflow.newUntypedChildWorkflowStub("SignalingChild_execute");
 
     private final CompletablePromise<Object> fromSignal = Workflow.newPromise();
 
@@ -3383,7 +3376,7 @@ public class WorkflowTest {
 
     WorkflowStub client =
         workflowClient.newUntypedWorkflowStub(
-            "TestWorkflowWithCronSchedule::execute",
+            "TestWorkflowWithCronSchedule_execute",
             newWorkflowOptionsBuilder(taskList)
                 .setExecutionStartToCloseTimeout(Duration.ofHours(1))
                 .setCronSchedule("0 * * * *")
@@ -3422,7 +3415,7 @@ public class WorkflowTest {
 
     WorkflowStub client =
         workflowClient.newUntypedWorkflowStub(
-            "TestWorkflow1::execute",
+            "TestWorkflow1_execute",
             newWorkflowOptionsBuilder(taskList)
                 .setExecutionStartToCloseTimeout(Duration.ofHours(10))
                 .build());
@@ -4067,7 +4060,7 @@ public class WorkflowTest {
     assertEquals("activity22activity1activity1activity1", result);
     tracer.setExpected(
         "getVersion",
-        "executeActivity TestActivities::activity2",
+        "executeActivity TestActivities_activity2",
         "getVersion",
         "executeActivity customActivity1",
         "executeActivity customActivity1",
@@ -4203,8 +4196,8 @@ public class WorkflowTest {
     assertEquals("activity22activity", result);
     tracer.setExpected(
         "getVersion",
-        "executeActivity TestActivities::activity2",
-        "executeActivity TestActivities::activity");
+        "executeActivity TestActivities_activity2",
+        "executeActivity TestActivities_activity");
   }
 
   // The following test covers the scenario where getVersion call is removed before another
@@ -4236,7 +4229,7 @@ public class WorkflowTest {
             TestWorkflow1.class, newWorkflowOptionsBuilder(taskList).build());
     String result = workflowStub.execute(taskList);
     assertEquals("activity", result);
-    tracer.setExpected("getVersion", "getVersion", "executeActivity TestActivities::activity");
+    tracer.setExpected("getVersion", "getVersion", "executeActivity TestActivities_activity");
   }
 
   public static class TestVersionNotSupportedWorkflowImpl implements TestWorkflow1 {
@@ -4423,7 +4416,7 @@ public class WorkflowTest {
             TestWorkflow1.class, newWorkflowOptionsBuilder(taskList).build());
     String result = workflowStub.execute(taskList);
     assertEquals("foo10", result);
-    tracer.setExpected("sideEffect", "sideEffect", "executeActivity TestActivities::activity2");
+    tracer.setExpected("sideEffect", "sideEffect", "executeActivity TestActivities_activity2");
   }
 
   public interface GenericParametersActivity {
@@ -4605,13 +4598,13 @@ public class WorkflowTest {
                   .setScheduleToCloseTimeout(Duration.ofSeconds(5))
                   .build());
       try {
-        activity.execute("NonDeserializableArgumentsActivity::execute", Void.class, "boo");
+        activity.execute("NonDeserializableArgumentsActivity_execute", Void.class, "boo");
       } catch (ActivityFailureException e) {
         result.append(e.getCause().getClass().getSimpleName());
       }
       result.append("-");
       try {
-        localActivity.execute("NonDeserializableArgumentsActivity::execute", Void.class, "boo");
+        localActivity.execute("NonDeserializableArgumentsActivity_execute", Void.class, "boo");
       } catch (ActivityFailureException e) {
         result.append(e.getCause().getClass().getSimpleName());
       }
@@ -4770,7 +4763,7 @@ public class WorkflowTest {
         localActivities.throwIO();
       } catch (ActivityFailureException e) {
         try {
-          assertTrue(e.getMessage().contains("TestActivities::throwIO"));
+          assertTrue(e.getMessage().contains("TestActivities_throwIO"));
           assertTrue(e.getCause() instanceof IOException);
           assertEquals("simulated IO problem", e.getCause().getMessage());
         } catch (AssertionError ae) {
@@ -5215,10 +5208,10 @@ public class WorkflowTest {
     sagaWorkflow.execute(taskList, false);
     tracer.setExpected(
         "executeActivity customActivity1",
-        "executeChildWorkflow TestMultiargsWorkflowsFunc::func",
-        "executeActivity TestActivities::throwIO",
-        "executeChildWorkflow TestCompensationWorkflow::compensate",
-        "executeActivity TestActivities::activity2");
+        "executeChildWorkflow TestMultiargsWorkflowsFunc_func",
+        "executeActivity TestActivities_throwIO",
+        "executeChildWorkflow TestCompensationWorkflow_compensate",
+        "executeActivity TestActivities_activity2");
   }
 
   @Test
@@ -5232,8 +5225,8 @@ public class WorkflowTest {
             TestSagaWorkflow.class, newWorkflowOptionsBuilder(taskList).build());
     sagaWorkflow.execute(taskList, true);
     String trace = tracer.getTrace();
-    assertTrue(trace, trace.contains("executeChildWorkflow TestCompensationWorkflow::compensate"));
-    assertTrue(trace, trace.contains("executeActivity TestActivities::activity2"));
+    assertTrue(trace, trace.contains("executeChildWorkflow TestCompensationWorkflow_compensate"));
+    assertTrue(trace, trace.contains("executeActivity TestActivities_activity2"));
   }
 
   public static class TestSignalExceptionWorkflowImpl implements TestWorkflowSignaled {
@@ -5335,7 +5328,7 @@ public class WorkflowTest {
             TestUpsertSearchAttributes.class, newWorkflowOptionsBuilder(taskList).build());
     String result = testWorkflow.execute(taskList, "testKey");
     assertEquals("done", result);
-    tracer.setExpected("upsertSearchAttributes", "executeActivity TestActivities::activity");
+    tracer.setExpected("upsertSearchAttributes", "executeActivity TestActivities_activity");
   }
 
   public static class TestMultiargsWorkflowsFuncChild implements TestMultiargsWorkflowsFunc2 {

--- a/src/test/resources/resetWorkflowHistory.json
+++ b/src/test/resources/resetWorkflowHistory.json
@@ -7,7 +7,7 @@
     "taskId": 1049398,
     "workflowExecutionStartedEventAttributes": {
       "workflowType": {
-        "name": "TestWorkflow1::execute"
+        "name": "TestWorkflow1_execute"
       },
       "taskList": {
         "name": "WorkflowTest-testWorkflowReset[Docker Sticky OFF]-2ac130cd-f7fb-48db-8c06-a7b8db8906fd"
@@ -68,7 +68,7 @@
     "activityTaskScheduledEventAttributes": {
       "activityId": "1",
       "activityType": {
-        "name": "TestActivities::activity"
+        "name": "TestActivities_activity"
       },
       "taskList": {
         "name": "WorkflowTest-testWorkflowReset[Docker Sticky OFF]-2ac130cd-f7fb-48db-8c06-a7b8db8906fd"
@@ -154,7 +154,7 @@
       "domain": "UnitTest",
       "workflowId": "ab7d2f10-06c6-3954-9a83-bdd53ed81b9a",
       "workflowType": {
-        "name": "TestMultiargsWorkflowsFunc::func"
+        "name": "TestMultiargsWorkflowsFunc_func"
       },
       "taskList": {
         "name": "WorkflowTest-testWorkflowReset[Docker Sticky OFF]-2ac130cd-f7fb-48db-8c06-a7b8db8906fd"
@@ -187,7 +187,7 @@
         "runId": "e127306b-11f7-4733-a69d-d154cf218964"
       },
       "workflowType": {
-        "name": "TestMultiargsWorkflowsFunc::func"
+        "name": "TestMultiargsWorkflowsFunc_func"
       }
     }
   },
@@ -243,7 +243,7 @@
         "runId": "e127306b-11f7-4733-a69d-d154cf218964"
       },
       "workflowType": {
-        "name": "TestMultiargsWorkflowsFunc::func"
+        "name": "TestMultiargsWorkflowsFunc_func"
       },
       "initiatedEventId": 11,
       "startedEventId": 12
@@ -339,7 +339,7 @@
     "activityTaskScheduledEventAttributes": {
       "activityId": "5",
       "activityType": {
-        "name": "TestActivities::activity"
+        "name": "TestActivities_activity"
       },
       "taskList": {
         "name": "WorkflowTest-testWorkflowReset[Docker Sticky OFF]-2ac130cd-f7fb-48db-8c06-a7b8db8906fd"
@@ -425,7 +425,7 @@
       "domain": "UnitTest",
       "workflowId": "f97d06d4-cfe2-372f-a0ca-d8d6276509c8",
       "workflowType": {
-        "name": "TestMultiargsWorkflowsFunc::func"
+        "name": "TestMultiargsWorkflowsFunc_func"
       },
       "taskList": {
         "name": "WorkflowTest-testWorkflowReset[Docker Sticky OFF]-2ac130cd-f7fb-48db-8c06-a7b8db8906fd"
@@ -458,7 +458,7 @@
         "runId": "f5037dc5-9f7c-423c-935e-e1ddb7d5b934"
       },
       "workflowType": {
-        "name": "TestMultiargsWorkflowsFunc::func"
+        "name": "TestMultiargsWorkflowsFunc_func"
       }
     }
   },
@@ -490,7 +490,7 @@
         "runId": "f5037dc5-9f7c-423c-935e-e1ddb7d5b934"
       },
       "workflowType": {
-        "name": "TestMultiargsWorkflowsFunc::func"
+        "name": "TestMultiargsWorkflowsFunc_func"
       },
       "initiatedEventId": 29,
       "startedEventId": 30
@@ -529,7 +529,7 @@
     "activityTaskScheduledEventAttributes": {
       "activityId": "9",
       "activityType": {
-        "name": "TestActivities::activity"
+        "name": "TestActivities_activity"
       },
       "taskList": {
         "name": "WorkflowTest-testWorkflowReset[Docker Sticky OFF]-2ac130cd-f7fb-48db-8c06-a7b8db8906fd"
@@ -615,7 +615,7 @@
       "domain": "UnitTest",
       "workflowId": "558b6d2b-22c6-37f8-bd02-2000f323c767",
       "workflowType": {
-        "name": "TestMultiargsWorkflowsFunc::func"
+        "name": "TestMultiargsWorkflowsFunc_func"
       },
       "taskList": {
         "name": "WorkflowTest-testWorkflowReset[Docker Sticky OFF]-2ac130cd-f7fb-48db-8c06-a7b8db8906fd"
@@ -648,7 +648,7 @@
         "runId": "741a8a94-c511-4cf8-9ac9-73588c039713"
       },
       "workflowType": {
-        "name": "TestMultiargsWorkflowsFunc::func"
+        "name": "TestMultiargsWorkflowsFunc_func"
       }
     }
   },
@@ -704,7 +704,7 @@
         "runId": "741a8a94-c511-4cf8-9ac9-73588c039713"
       },
       "workflowType": {
-        "name": "TestMultiargsWorkflowsFunc::func"
+        "name": "TestMultiargsWorkflowsFunc_func"
       },
       "initiatedEventId": 41,
       "startedEventId": 42
@@ -757,7 +757,7 @@
     "activityTaskScheduledEventAttributes": {
       "activityId": "13",
       "activityType": {
-        "name": "TestActivities::activity"
+        "name": "TestActivities_activity"
       },
       "taskList": {
         "name": "WorkflowTest-testWorkflowReset[Docker Sticky OFF]-2ac130cd-f7fb-48db-8c06-a7b8db8906fd"
@@ -842,7 +842,7 @@
     "activityTaskScheduledEventAttributes": {
       "activityId": "15",
       "activityType": {
-        "name": "TestActivities::activity"
+        "name": "TestActivities_activity"
       },
       "taskList": {
         "name": "WorkflowTest-testWorkflowReset[Docker Sticky OFF]-2ac130cd-f7fb-48db-8c06-a7b8db8906fd"
@@ -970,7 +970,7 @@
     "activityTaskScheduledEventAttributes": {
       "activityId": "17",
       "activityType": {
-        "name": "TestActivities::activity"
+        "name": "TestActivities_activity"
       },
       "taskList": {
         "name": "WorkflowTest-testWorkflowReset[Docker Sticky OFF]-2ac130cd-f7fb-48db-8c06-a7b8db8906fd"
@@ -1056,7 +1056,7 @@
       "domain": "UnitTest",
       "workflowId": "b1c2d938-8490-34b3-acf4-138c591deb62",
       "workflowType": {
-        "name": "TestMultiargsWorkflowsFunc::func"
+        "name": "TestMultiargsWorkflowsFunc_func"
       },
       "taskList": {
         "name": "WorkflowTest-testWorkflowReset[Docker Sticky OFF]-2ac130cd-f7fb-48db-8c06-a7b8db8906fd"
@@ -1089,7 +1089,7 @@
         "runId": "18c47f68-3b5a-41d1-92a1-2e11d5e92bc7"
       },
       "workflowType": {
-        "name": "TestMultiargsWorkflowsFunc::func"
+        "name": "TestMultiargsWorkflowsFunc_func"
       }
     }
   },
@@ -1121,7 +1121,7 @@
         "runId": "18c47f68-3b5a-41d1-92a1-2e11d5e92bc7"
       },
       "workflowType": {
-        "name": "TestMultiargsWorkflowsFunc::func"
+        "name": "TestMultiargsWorkflowsFunc_func"
       },
       "initiatedEventId": 71,
       "startedEventId": 72

--- a/src/test/resources/testAsyncActivityRetryHistory.json
+++ b/src/test/resources/testAsyncActivityRetryHistory.json
@@ -6,7 +6,7 @@
     "version": -24,
     "workflowExecutionStartedEventAttributes": {
       "workflowType": {
-        "name": "TestWorkflow1::execute"
+        "name": "TestWorkflow1_execute"
       },
       "taskList": {
         "name": "WorkflowTest-testAsyncActivityRetry[Docker Sticky ON]-3f9e1f99-7718-4975-a8a3-c0dfdaee42f7"
@@ -72,7 +72,7 @@
     "activityTaskScheduledEventAttributes": {
       "activityId": "1",
       "activityType": {
-        "name": "TestActivities::throwIO"
+        "name": "TestActivities_throwIO"
       },
       "taskList": {
         "name": "WorkflowTest-testAsyncActivityRetry[Docker Sticky ON]-3f9e1f99-7718-4975-a8a3-c0dfdaee42f7"
@@ -219,7 +219,7 @@
     "activityTaskScheduledEventAttributes": {
       "activityId": "3",
       "activityType": {
-        "name": "TestActivities::throwIO"
+        "name": "TestActivities_throwIO"
       },
       "taskList": {
         "name": "WorkflowTest-testAsyncActivityRetry[Docker Sticky ON]-3f9e1f99-7718-4975-a8a3-c0dfdaee42f7"
@@ -366,7 +366,7 @@
     "activityTaskScheduledEventAttributes": {
       "activityId": "5",
       "activityType": {
-        "name": "TestActivities::throwIO"
+        "name": "TestActivities_throwIO"
       },
       "taskList": {
         "name": "WorkflowTest-testAsyncActivityRetry[Docker Sticky ON]-3f9e1f99-7718-4975-a8a3-c0dfdaee42f7"

--- a/src/test/resources/testChildWorkflowRetryHistory.json
+++ b/src/test/resources/testChildWorkflowRetryHistory.json
@@ -6,7 +6,7 @@
     "version": -24,
     "workflowExecutionStartedEventAttributes": {
       "workflowType": {
-        "name": "TestWorkflow1::execute"
+        "name": "TestWorkflow1_execute"
       },
       "taskList": {
         "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky ON]-7f1642a9-9092-4ab1-9820-ffdf9eec95ce"
@@ -73,7 +73,7 @@
       "domain": "UnitTest",
       "workflowId": "c766b1bc-a4a2-369f-93f4-15be09faf4bb",
       "workflowType": {
-        "name": "ITestChild::execute"
+        "name": "ITestChild_execute"
       },
       "taskList": {
         "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky ON]-7f1642a9-9092-4ab1-9820-ffdf9eec95ce"
@@ -99,7 +99,7 @@
         "runId": "102e3eee-510c-4b3a-9770-75183a250fe2"
       },
       "workflowType": {
-        "name": "ITestChild::execute"
+        "name": "ITestChild_execute"
       }
     }
   },
@@ -152,7 +152,7 @@
         "runId": "102e3eee-510c-4b3a-9770-75183a250fe2"
       },
       "workflowType": {
-        "name": "ITestChild::execute"
+        "name": "ITestChild_execute"
       },
       "initiatedEventId": 6,
       "startedEventId": 7
@@ -269,7 +269,7 @@
       "domain": "UnitTest",
       "workflowId": "ae895176-b277-32c0-a73c-00d437f99e69",
       "workflowType": {
-        "name": "ITestChild::execute"
+        "name": "ITestChild_execute"
       },
       "taskList": {
         "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky ON]-7f1642a9-9092-4ab1-9820-ffdf9eec95ce"
@@ -295,7 +295,7 @@
         "runId": "bfc14ce9-57fd-4345-a1d0-96b34ce85694"
       },
       "workflowType": {
-        "name": "ITestChild::execute"
+        "name": "ITestChild_execute"
       }
     }
   },
@@ -348,7 +348,7 @@
         "runId": "bfc14ce9-57fd-4345-a1d0-96b34ce85694"
       },
       "workflowType": {
-        "name": "ITestChild::execute"
+        "name": "ITestChild_execute"
       },
       "initiatedEventId": 21,
       "startedEventId": 22
@@ -465,7 +465,7 @@
       "domain": "UnitTest",
       "workflowId": "6fb308b0-2d80-3efe-8334-6fe812a2debe",
       "workflowType": {
-        "name": "ITestChild::execute"
+        "name": "ITestChild_execute"
       },
       "taskList": {
         "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky ON]-7f1642a9-9092-4ab1-9820-ffdf9eec95ce"
@@ -491,7 +491,7 @@
         "runId": "421fd6ab-a552-47a1-881f-1bbc3650412e"
       },
       "workflowType": {
-        "name": "ITestChild::execute"
+        "name": "ITestChild_execute"
       }
     }
   },
@@ -544,7 +544,7 @@
         "runId": "421fd6ab-a552-47a1-881f-1bbc3650412e"
       },
       "workflowType": {
-        "name": "ITestChild::execute"
+        "name": "ITestChild_execute"
       },
       "initiatedEventId": 36,
       "startedEventId": 37

--- a/src/test/resources/testMutableSideEffectBackwardCompatibility.json
+++ b/src/test/resources/testMutableSideEffectBackwardCompatibility.json
@@ -9,7 +9,7 @@
       "version": -24,
       "workflowExecutionStartedEventAttributes": {
         "workflowType": {
-          "name": "TestWorkflow1::execute"
+          "name": "TestWorkflow1_execute"
         },
         "taskList": {
           "name": "WorkflowTest-testMutableSideEffect[Docker Sticky ON]-53e839aa-7dab-4cb0-9e65-a73c97a53815"

--- a/src/test/resources/timerfiring.json
+++ b/src/test/resources/timerfiring.json
@@ -6,7 +6,7 @@
     "version": -24,
     "workflowExecutionStartedEventAttributes": {
       "workflowType": {
-        "name": "GreetingWorkflow::createGreeting"
+        "name": "GreetingWorkflow_createGreeting"
       },
       "taskList": {
         "name": "HelloQuery"
@@ -62,7 +62,7 @@
     "activityTaskScheduledEventAttributes": {
       "activityId": "0",
       "activityType": {
-        "name": "GreetingActivities::composeGreeting"
+        "name": "GreetingActivities_composeGreeting"
       },
       "taskList": {
         "name": "HelloQuery"


### PR DESCRIPTION
The activity and workflow names are used in metrics reporting. Prometheus has pretty strict restrictions around the names. So replacing "::" separator with "_".