### PR TITLE
Added logic to skip localhost name lookup on mac

### DIFF
--- a/src/main/java/io/temporal/client/WorkflowClientOptions.java
+++ b/src/main/java/io/temporal/client/WorkflowClientOptions.java
@@ -116,7 +116,7 @@ public final class WorkflowClientOptions {
      * correspondent ActivityTaskStarted event contains the worker identity as a field. Default is
      * "unknown-mac" string on Mac or whatever <code>(ManagementFactory.getRuntimeMXBean().getName()
      * </code> returns on any other platform. The reason for treating Mac differently is a very slow
-     * local host name resolution in default configuration.
+     * local host name resolution in a default configuration.
      *
      * @return
      */

--- a/src/main/java/io/temporal/client/WorkflowClientOptions.java
+++ b/src/main/java/io/temporal/client/WorkflowClientOptions.java
@@ -114,7 +114,9 @@ public final class WorkflowClientOptions {
      * Override human readable identity of the worker. Identity is used to identify a worker and is
      * recorded in the workflow history events. For example when a worker gets an activity task the
      * correspondent ActivityTaskStarted event contains the worker identity as a field. Default is
-     * whatever <code>(ManagementFactory.getRuntimeMXBean().getName()</code> returns.
+     * "unknown-mac" string on Mac or whatever <code>(ManagementFactory.getRuntimeMXBean().getName()
+     * </code> returns on any other platform. The reason for treating Mac differently is a very slow
+     * local host name resolution in default configuration.
      *
      * @return
      */
@@ -134,12 +136,26 @@ public final class WorkflowClientOptions {
     }
 
     public WorkflowClientOptions validateAndBuildWithDefaults() {
+      String name;
+      if (identity == null) {
+        String osName = System.getProperty("os.name");
+        // On mac by default getLocalHost (which getRuntimeMXBean().getName() calls) takes long
+        // time. So we don't set identity on mac by default to avoid the bad user experience.
+        // https://stackoverflow.com/questions/33289695/inetaddress-getlocalhost-slow-to-run-30-seconds
+        if (osName.toLowerCase().contains("mac")) {
+          name = "unknown-mac";
+        } else {
+          name = ManagementFactory.getRuntimeMXBean().getName();
+        }
+      } else {
+        name = identity;
+      }
       return new WorkflowClientOptions(
           domain == null ? DEFAULT_DOMAIN : domain,
           dataConverter == null ? JsonDataConverter.getInstance() : dataConverter,
           interceptors == null ? EMPTY_INTERCEPTOR_ARRAY : interceptors,
           metricsScope == null ? NoopScope.getInstance() : metricsScope,
-          identity == null ? ManagementFactory.getRuntimeMXBean().getName() : identity,
+          name,
           contextPropagators == null ? EMPTY_CONTEXT_PROPAGATORS : contextPropagators);
     }
   }

--- a/src/main/java/io/temporal/internal/sync/TestWorkflowEnvironmentInternal.java
+++ b/src/main/java/io/temporal/internal/sync/TestWorkflowEnvironmentInternal.java
@@ -136,7 +136,7 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
     workerFactory.shutdownNow();
     workerFactory.awaitTermination(10, TimeUnit.SECONDS);
     service.close();
-    workflowServiceStubs.shutdownNow();
+    workflowServiceStubs.shutdown();
     try {
       workflowServiceStubs.awaitTermination(10, TimeUnit.SECONDS);
     } catch (InterruptedException e) {

--- a/src/main/java/io/temporal/worker/WorkerFactory.java
+++ b/src/main/java/io/temporal/worker/WorkerFactory.java
@@ -34,8 +34,6 @@ import io.temporal.internal.worker.Poller;
 import io.temporal.internal.worker.PollerOptions;
 import io.temporal.internal.worker.WorkflowPollTaskFactory;
 import io.temporal.proto.workflowservice.PollForDecisionTaskResponse;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -106,7 +104,7 @@ public final class WorkerFactory {
             .tagged(
                 new ImmutableMap.Builder<String, String>(2)
                     .put(MetricsTag.DOMAIN, workflowClient.getOptions().getDomain())
-                    .put(MetricsTag.TASK_LIST, getHostName())
+                    .put(MetricsTag.TASK_LIST, workflowClient.getOptions().getIdentity())
                     .build());
 
     this.cache = new DeciderCache(this.factoryOptions.getCacheMaximumSize(), metricsScope);
@@ -295,17 +293,8 @@ public final class WorkerFactory {
     return this.cache;
   }
 
-  @VisibleForTesting
-  String getHostName() {
-    try {
-      return InetAddress.getLocalHost().getHostName();
-    } catch (UnknownHostException e) {
-      return "UnknownHost";
-    }
-  }
-
   private String getStickyTaskListName() {
-    return String.format("%s:%s", getHostName(), id);
+    return String.format("%s:%s", workflowClient.getOptions().getIdentity(), id);
   }
 
   public synchronized void suspendPolling() {

--- a/src/test/java/io/temporal/workflow/WorkflowTest.java
+++ b/src/test/java/io/temporal/workflow/WorkflowTest.java
@@ -2445,6 +2445,7 @@ public class WorkflowTest {
         execution.toString(),
         WorkflowExecutionCloseStatus.WorkflowExecutionCloseStatusCompleted,
         queryResponse.getQueryRejected().getCloseStatus());
+    log.info("testSignalUntyped completed");
   }
 
   static final AtomicInteger decisionCount = new AtomicInteger();

--- a/src/test/java/io/temporal/workflow/WorkflowTest.java
+++ b/src/test/java/io/temporal/workflow/WorkflowTest.java
@@ -150,9 +150,7 @@ public class WorkflowTest {
 
   @Rule public TestName testName = new TestName();
 
-  @Rule
-  public Timeout globalTimeout =
-      Timeout.seconds(DEBUGGER_TIMEOUTS ? 500 : 30);
+  @Rule public Timeout globalTimeout = Timeout.seconds(DEBUGGER_TIMEOUTS ? 500 : 30);
 
   @Rule
   public TestWatcher watchman =


### PR DESCRIPTION
The default identity logic that calls ManagementFactory.getRuntimeMXBean().getName() creates very bad user experience on Mac which takes 5+ seconds to return.  This change skips this call on mac. If a mac user wants to set identity he can always set ClientOptions.idenity property himself.