### PR TITLE
Added ability to register signal listener from workflow code

### DIFF
--- a/src/main/java/io/temporal/common/interceptors/WorkflowCallsInterceptor.java
+++ b/src/main/java/io/temporal/common/interceptors/WorkflowCallsInterceptor.java
@@ -114,6 +114,8 @@ public interface WorkflowCallsInterceptor {
 
   void registerQuery(String queryType, Type[] argTypes, Functions.Func1<Object[], Object> callback);
 
+  void registerSignal(String signalType, Type[] argTypes, Functions.Proc1<Object[]> callback);
+
   UUID randomUUID();
 
   void upsertSearchAttributes(Map<String, Object> searchAttributes);

--- a/src/main/java/io/temporal/common/interceptors/WorkflowCallsInterceptorBase.java
+++ b/src/main/java/io/temporal/common/interceptors/WorkflowCallsInterceptorBase.java
@@ -24,6 +24,7 @@ import io.temporal.activity.LocalActivityOptions;
 import io.temporal.proto.common.WorkflowExecution;
 import io.temporal.workflow.ChildWorkflowOptions;
 import io.temporal.workflow.ContinueAsNewOptions;
+import io.temporal.workflow.Functions;
 import io.temporal.workflow.Functions.Func;
 import io.temporal.workflow.Functions.Func1;
 import io.temporal.workflow.Promise;
@@ -136,6 +137,12 @@ public class WorkflowCallsInterceptorBase implements WorkflowCallsInterceptor {
   @Override
   public void registerQuery(String queryType, Type[] argTypes, Func1<Object[], Object> callback) {
     next.registerQuery(queryType, argTypes, callback);
+  }
+
+  @Override
+  public void registerSignal(
+      String signalType, Type[] argTypes, Functions.Proc1<Object[]> callback) {
+    next.registerSignal(signalType, argTypes, callback);
   }
 
   @Override

--- a/src/main/java/io/temporal/internal/external/GenericWorkflowClientExternalImpl.java
+++ b/src/main/java/io/temporal/internal/external/GenericWorkflowClientExternalImpl.java
@@ -327,7 +327,15 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
             .build();
     return GrpcRetryer.retryWithResult(
         GrpcRetryer.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
-        () -> service.blockingStub().queryWorkflow(request));
+        () -> {
+          try {
+            QueryWorkflowResponse result = service.blockingStub().queryWorkflow(request);
+            System.out.println(result);
+            return result;
+          } catch (RuntimeException e) {
+            throw e;
+          }
+        });
   }
 
   @Override

--- a/src/main/java/io/temporal/internal/sync/SyncDecisionContext.java
+++ b/src/main/java/io/temporal/internal/sync/SyncDecisionContext.java
@@ -27,9 +27,11 @@ import io.temporal.activity.LocalActivityOptions;
 import io.temporal.common.RetryOptions;
 import io.temporal.common.context.ContextPropagator;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DataConverterException;
 import io.temporal.common.interceptors.WorkflowCallsInterceptor;
 import io.temporal.internal.common.InternalUtils;
 import io.temporal.internal.common.RetryParameters;
+import io.temporal.internal.metrics.MetricsType;
 import io.temporal.internal.replay.ActivityTaskFailedException;
 import io.temporal.internal.replay.ActivityTaskTimeoutException;
 import io.temporal.internal.replay.ChildWorkflowTaskFailedException;
@@ -60,6 +62,7 @@ import io.temporal.workflow.SignalExternalWorkflowException;
 import io.temporal.workflow.Workflow;
 import java.lang.reflect.Type;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,6 +81,24 @@ import org.slf4j.LoggerFactory;
 
 final class SyncDecisionContext implements WorkflowCallsInterceptor {
 
+  private static class SignalData {
+    private final byte[] payload;
+    private final long eventId;
+
+    private SignalData(byte[] payload, long eventId) {
+      this.payload = payload;
+      this.eventId = eventId;
+    }
+
+    public byte[] getPayload() {
+      return payload;
+    }
+
+    public long getEventId() {
+      return eventId;
+    }
+  }
+
   private static final Logger log = LoggerFactory.getLogger(SyncDecisionContext.class);
 
   private final DecisionContext context;
@@ -87,6 +108,12 @@ final class SyncDecisionContext implements WorkflowCallsInterceptor {
   private WorkflowCallsInterceptor headInterceptor;
   private final WorkflowTimers timers = new WorkflowTimers();
   private final Map<String, Functions.Func1<byte[], byte[]>> queryCallbacks = new HashMap<>();
+  private final Map<String, Functions.Proc2<byte[], Long>> signalCallbacks = new HashMap<>();
+  /**
+   * Buffers signals which don't have registered listener. Key is signal type. Value is signal data.
+   */
+  private final Map<String, List<SignalData>> signalBuffers = new HashMap<>();
+
   private final byte[] lastCompletionResult;
 
   public SyncDecisionContext(
@@ -582,6 +609,20 @@ final class SyncDecisionContext implements WorkflowCallsInterceptor {
     return callback.apply(args);
   }
 
+  public void signal(String signalName, byte[] args, long eventId) {
+    Functions.Proc2<byte[], Long> callback = signalCallbacks.get(signalName);
+    if (callback == null) {
+      List<SignalData> buffer = signalBuffers.get(signalName);
+      if (buffer == null) {
+        buffer = new ArrayList<>();
+        signalBuffers.put(signalName, buffer);
+      }
+      buffer.add(new SignalData(args, eventId));
+    } else {
+      callback.apply(args, eventId);
+    }
+  }
+
   @Override
   public void registerQuery(
       String queryType, Type[] argTypes, Functions.Func1<Object[], Object> callback) {
@@ -595,6 +636,42 @@ final class SyncDecisionContext implements WorkflowCallsInterceptor {
           Object result = callback.apply(args);
           return converter.toData(result);
         });
+  }
+
+  @Override
+  public void registerSignal(
+      String signalType, Type[] argTypes, Functions.Proc1<Object[]> callback) {
+    if (signalCallbacks.containsKey(signalType)) {
+      throw new IllegalStateException("Signal \"" + signalType + "\" is already registered");
+    }
+    Functions.Proc2<byte[], Long> signalCallback =
+        (input, eventId) -> {
+          try {
+            Object[] args = converter.fromDataArray(input, argTypes);
+            callback.apply(args);
+          } catch (DataConverterException e) {
+            logSerializationException(signalType, eventId, e);
+          }
+        };
+    List<SignalData> buffer = signalBuffers.remove(signalType);
+    if (buffer != null) {
+      for (SignalData signalData : buffer) {
+        signalCallback.apply(signalData.getPayload(), signalData.getEventId());
+      }
+    }
+    signalCallbacks.put(signalType, signalCallback);
+  }
+
+  void logSerializationException(
+      String signalName, Long eventId, DataConverterException exception) {
+    log.error(
+        "Failure deserializing signal input for \""
+            + signalName
+            + "\" at eventId "
+            + eventId
+            + ". Dropping it.",
+        exception);
+    Workflow.getMetricsScope().counter(MetricsType.CORRUPTED_SIGNALS_COUNTER).inc(1);
   }
 
   @Override

--- a/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
+++ b/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
@@ -120,9 +120,8 @@ class SyncWorkflow implements ReplayWorkflow {
 
   @Override
   public void handleSignal(String signalName, byte[] input, long eventId) {
-    String threadName = "\"" + signalName + "\" signal handler";
     runner.executeInWorkflowThread(
-        threadName, () -> workflowProc.processSignal(signalName, input, eventId));
+        "signal " + signalName, () -> workflowProc.processSignal(signalName, input, eventId));
   }
 
   @Override

--- a/src/main/java/io/temporal/internal/sync/SyncWorkflowDefinition.java
+++ b/src/main/java/io/temporal/internal/sync/SyncWorkflowDefinition.java
@@ -21,15 +21,8 @@ package io.temporal.internal.sync;
 
 interface SyncWorkflowDefinition {
 
-  /**
-   * Always called first. Usually {@link #execute(byte[])} is called after that and then potentially
-   * multiple {@link #processSignal(String, byte[], long)} while execute is running. But in case of
-   * signalWithStart {@link #processSignal(String, byte[], long)} can be called before the {@link
-   * #execute(byte[])}.
-   */
+  /** Always called first. */
   void initialize();
 
   byte[] execute(byte[] input);
-
-  void processSignal(String signalName, byte[] input, long eventId);
 }

--- a/src/main/java/io/temporal/internal/sync/TestActivityEnvironmentInternal.java
+++ b/src/main/java/io/temporal/internal/sync/TestActivityEnvironmentInternal.java
@@ -51,6 +51,7 @@ import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.workflow.ActivityFailureException;
 import io.temporal.workflow.ChildWorkflowOptions;
 import io.temporal.workflow.ContinueAsNewOptions;
+import io.temporal.workflow.Functions;
 import io.temporal.workflow.Functions.Func;
 import io.temporal.workflow.Functions.Func1;
 import io.temporal.workflow.Promise;
@@ -327,6 +328,12 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
 
     @Override
     public void registerQuery(String queryType, Type[] argTypes, Func1<Object[], Object> callback) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public void registerSignal(
+        String signalType, Type[] argTypes, Functions.Proc1<Object[]> callback) {
       throw new UnsupportedOperationException("not implemented");
     }
 

--- a/src/main/java/io/temporal/internal/sync/WorkflowExecuteRunnable.java
+++ b/src/main/java/io/temporal/internal/sync/WorkflowExecuteRunnable.java
@@ -64,7 +64,7 @@ class WorkflowExecuteRunnable implements Runnable {
   public void close() {}
 
   public void processSignal(String signalName, byte[] input, long eventId) {
-    workflow.processSignal(signalName, input, eventId);
+    context.signal(signalName, input, eventId);
   }
 
   public byte[] query(String type, byte[] args) {

--- a/src/main/java/io/temporal/workflow/Workflow.java
+++ b/src/main/java/io/temporal/workflow/Workflow.java
@@ -700,17 +700,15 @@ public final class Workflow {
   }
 
   /**
-   * Register query or queries implementation object. The object must implement at least one
-   * interface annotated with {@link WorkflowInterface}. Only methods annotated with @{@link
-   * QueryMethod} are registered.
+   * Registers an implementation object. The object must implement at least one interface annotated
+   * with {@link WorkflowInterface}. All its methods annotated with @{@link SignalMethod}
+   * and @{@link QueryMethod} are registered.
    *
-   * <p>There is no need to register top level workflow implementation object as it is done
+   * <p>There is no need to register the top level workflow implementation object as it is done
    * implicitly by the framework on object startup.
    *
    * <p>An attempt to register a duplicated query is going to fail with {@link
    * IllegalArgumentException}
-   *
-   * <p>TODO: Add registration of methods annotated with @SignalMethod
    */
   public static void registerListener(Object queryImplementation) {
     WorkflowInternal.registerListener(queryImplementation);

--- a/src/test/java/io/temporal/workflow/WorkflowTest.java
+++ b/src/test/java/io/temporal/workflow/WorkflowTest.java
@@ -3027,6 +3027,7 @@ public class WorkflowTest {
     WorkflowStub stub = WorkflowStub.fromTyped(client);
     tracer.setExpected(
         "interceptExecuteWorkflow " + stub.getExecution().getWorkflowId(),
+        "registerSignal testSignal",
         "executeChildWorkflow SignalingChild_execute",
         "interceptExecuteWorkflow " + UUID_REGEXP, // child
         "signalExternalWorkflow " + UUID_REGEXP + " testSignal");
@@ -5713,6 +5714,13 @@ public class WorkflowTest {
     public void registerQuery(String queryType, Type[] argTypes, Func1<Object[], Object> callback) {
       trace.add("registerQuery " + queryType);
       next.registerQuery(queryType, argTypes, callback);
+    }
+
+    @Override
+    public void registerSignal(
+        String signalType, Type[] argTypes, Functions.Proc1<Object[]> callback) {
+      trace.add("registerSignal " + signalType);
+      next.registerSignal(signalType, argTypes, callback);
     }
 
     @Override

--- a/src/test/java/io/temporal/workflow/interceptors/SignalWorkflowCallsInterceptor.java
+++ b/src/test/java/io/temporal/workflow/interceptors/SignalWorkflowCallsInterceptor.java
@@ -23,7 +23,10 @@ import io.temporal.activity.ActivityOptions;
 import io.temporal.activity.LocalActivityOptions;
 import io.temporal.common.interceptors.WorkflowCallsInterceptor;
 import io.temporal.proto.common.WorkflowExecution;
-import io.temporal.workflow.*;
+import io.temporal.workflow.ChildWorkflowOptions;
+import io.temporal.workflow.ContinueAsNewOptions;
+import io.temporal.workflow.Functions;
+import io.temporal.workflow.Promise;
 import java.lang.reflect.Type;
 import java.time.Duration;
 import java.util.Map;
@@ -150,6 +153,12 @@ public class SignalWorkflowCallsInterceptor implements WorkflowCallsInterceptor 
   public void registerQuery(
       String queryType, Type[] argTypes, Functions.Func1<Object[], Object> callback) {
     next.registerQuery(queryType, argTypes, callback);
+  }
+
+  @Override
+  public void registerSignal(
+      String signalType, Type[] argTypes, Functions.Proc1<Object[]> callback) {
+    next.registerSignal(signalType, argTypes, callback);
   }
 
   @Override


### PR DESCRIPTION
After this change it is possible to add a signal and query listener from a workflow code as:

```
  @WorkflowInterface
  public interface SignalQueryBase {
    @SignalMethod
    void signal(String arg);

    @QueryMethod
    String getSignal();
  }


  public static class TestSignalAndQueryListenerWorkflowImpl
      implements TestSignalAndQueryListenerWorkflow {

    private List<String> signals = new ArrayList<>();

    @Override
    public void execute() {
      Workflow.registerListener(
          new SignalQueryBase() {

            @Override
            public void signal(String arg) {
              signals.add(arg);
            }

            @Override
            public String getSignal() {
              return String.join(", ", signals);
            }
          });
          ...
          ...
    }
  }
```


