### PR TITLE
Changes to names of workflow and activity type as well as signal and query methods

### DIFF
--- a/docker/buildkite/docker-compose.yaml
+++ b/docker/buildkite/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       - "8126:8126"
 
   temporal:
-    image: temporalio/auto-setup:latest
+    image: temporalio/auto-setup:0.21.1
     logging:
       driver: none
     ports:

--- a/src/main/java/io/temporal/activity/ActivityInterface.java
+++ b/src/main/java/io/temporal/activity/ActivityInterface.java
@@ -75,4 +75,13 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface ActivityInterface {}
+public @interface ActivityInterface {
+  /**
+   * Prefix to prepend to method names to generate activity types. Default is empty string which
+   * means that method names are used as activity types.
+   *
+   * <p>Be careful about names that contain special characters. These names can be used as metric
+   * tags. And systems like prometheus ignore metrics which have tags with unsupported characters.
+   */
+  String namePrefix() default "";
+}

--- a/src/main/java/io/temporal/activity/ActivityMethod.java
+++ b/src/main/java/io/temporal/activity/ActivityMethod.java
@@ -32,6 +32,12 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 public @interface ActivityMethod {
 
-  /** Name of the workflow type. Default is {short class name}::{method name} */
+  /**
+   * Name of the activity type. Default is method name. Also consider using {@link
+   * ActivityInterface#namePrefix()}.
+   *
+   * <p>Be careful about names that contain special characters. These names can be used as metric
+   * tags. And systems like prometheus ignore metrics which have tags with unsupported characters.
+   */
   String name() default "";
 }

--- a/src/main/java/io/temporal/internal/sync/POJOActivityImplMetadata.java
+++ b/src/main/java/io/temporal/internal/sync/POJOActivityImplMetadata.java
@@ -86,8 +86,12 @@ class POJOActivityImplMetadata {
                   + methodMetadata.getName()
                   + "\" declared at \""
                   + registeredMM.getMethod()
+                  + "\" registered through \""
+                  + registeredMM.getInterfaceType()
                   + "\" and \""
                   + methodMetadata.getMethod()
+                  + "\" registered through \""
+                  + methodMetadata.getInterfaceType()
                   + "\"");
         }
       }

--- a/src/main/java/io/temporal/internal/sync/POJOActivityInterfaceMetadata.java
+++ b/src/main/java/io/temporal/internal/sync/POJOActivityInterfaceMetadata.java
@@ -149,7 +149,8 @@ class POJOActivityInterfaceMetadata {
       return result; // Not annotated just pass all the methods to the parent
     }
     for (Method method : result) {
-      POJOActivityMethodMetadata methodMetadata = new POJOActivityMethodMetadata(method, current);
+      POJOActivityMethodMetadata methodMetadata =
+          new POJOActivityMethodMetadata(method, current, annotation);
       EqualsByMethodName wrapped = new EqualsByMethodName(method);
       POJOActivityMethodMetadata registered = dedupeMap.put(wrapped, methodMetadata);
       if (registered != null) {

--- a/src/main/java/io/temporal/internal/sync/POJOActivityMethodMetadata.java
+++ b/src/main/java/io/temporal/internal/sync/POJOActivityMethodMetadata.java
@@ -20,6 +20,7 @@
 package io.temporal.internal.sync;
 
 import com.google.common.base.Strings;
+import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.ActivityMethod;
 import java.lang.reflect.Method;
 import java.util.Objects;
@@ -30,7 +31,8 @@ public class POJOActivityMethodMetadata {
   private final Method method;
   private final Class<?> interfaceType;
 
-  POJOActivityMethodMetadata(Method method, Class<?> interfaceType) {
+  POJOActivityMethodMetadata(
+      Method method, Class<?> interfaceType, ActivityInterface activityAnnotation) {
     this.method = Objects.requireNonNull(method);
     this.interfaceType = Objects.requireNonNull(interfaceType);
     ActivityMethod activityMethod = method.getAnnotation(ActivityMethod.class);
@@ -40,7 +42,7 @@ public class POJOActivityMethodMetadata {
       name = activityMethod.name();
     } else {
       hasActivityMethodAnnotation = false;
-      name = interfaceType.getSimpleName() + "_" + method.getName();
+      name = activityAnnotation.namePrefix() + method.getName();
     }
     this.name = name;
   }

--- a/src/main/java/io/temporal/internal/sync/POJOActivityTaskHandler.java
+++ b/src/main/java/io/temporal/internal/sync/POJOActivityTaskHandler.java
@@ -73,7 +73,7 @@ class POJOActivityTaskHandler implements ActivityTaskHandler {
     for (String activityType : activityMetadata.getActivityTypes()) {
       if (activities.containsKey(activityType)) {
         throw new IllegalArgumentException(
-            activityType + " activity type is already registered with the worker");
+            "\"" + activityType + "\" activity type is already registered with the worker");
       }
       Method method = activityMetadata.getMethodMetadata(activityType).getMethod();
       ActivityTaskExecutor implementation = newTaskExecutor.apply(method, activity);

--- a/src/main/java/io/temporal/internal/sync/POJOWorkflowMethodMetadata.java
+++ b/src/main/java/io/temporal/internal/sync/POJOWorkflowMethodMetadata.java
@@ -39,9 +39,11 @@ class POJOWorkflowMethodMetadata {
     }
     this.interfaceType = Objects.requireNonNull(interfaceType);
     Optional<String> nameFromAnnotation = workflowMethod.getNameFromAnnotation();
-    this.name =
-        nameFromAnnotation.orElse(
-            interfaceType.getSimpleName() + "_" + methodMetadata.getMethod().getName());
+    if (workflowMethod.getType() == WorkflowMethodType.WORKFLOW) {
+      this.name = nameFromAnnotation.orElse(interfaceType.getSimpleName());
+    } else {
+      this.name = nameFromAnnotation.orElse(methodMetadata.getMethod().getName());
+    }
   }
 
   public WorkflowMethodType getType() {

--- a/src/main/java/io/temporal/internal/testservice/StateMachine.java
+++ b/src/main/java/io/temporal/internal/testservice/StateMachine.java
@@ -223,7 +223,7 @@ final class StateMachine<Data> {
         (TransitionDestination<Data, R>) transitions.get(transition);
     if (destination == null) {
       throw Status.INTERNAL
-          .withDescription("Invalid " + transition + ", history: " + transitionHistory)
+          .withDescription(this.data + "Invalid " + transition + ", history: " + transitionHistory)
           .asRuntimeException();
     }
     state = destination.apply(context, data, request, referenceId);

--- a/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -158,6 +158,26 @@ class StateMachines {
       this.originalExecutionRunId = originalExecutionRunId;
       this.continuedExecutionRunId = continuedExecutionRunId;
     }
+
+    @Override
+    public String toString() {
+      return "WorkflowData{"
+          + "retryState="
+          + retryState
+          + ", backoffStartIntervalInSeconds="
+          + backoffStartIntervalInSeconds
+          + ", cronSchedule='"
+          + cronSchedule
+          + '\''
+          + ", lastCompletionResult="
+          + lastCompletionResult
+          + ", originalExecutionRunId='"
+          + originalExecutionRunId
+          + '\''
+          + ", continuedExecutionRunId="
+          + continuedExecutionRunId
+          + '}';
+    }
   }
 
   static final class DecisionTaskData {
@@ -177,6 +197,24 @@ class StateMachines {
     DecisionTaskData(long previousStartedEventId, TestWorkflowStore store) {
       this.previousStartedEventId = previousStartedEventId;
       this.store = store;
+    }
+
+    @Override
+    public String toString() {
+      return "DecisionTaskData{"
+          + "previousStartedEventId="
+          + previousStartedEventId
+          + ", store="
+          + store
+          + ", startedEventId="
+          + startedEventId
+          + ", decisionTask="
+          + decisionTask
+          + ", scheduledEventId="
+          + scheduledEventId
+          + ", attempt="
+          + attempt
+          + '}';
     }
   }
 
@@ -201,16 +239,64 @@ class StateMachines {
       this.store = store;
       this.startWorkflowExecutionRequest = startWorkflowExecutionRequest;
     }
+
+    @Override
+    public String toString() {
+      return "ActivityTaskData{"
+          + "startWorkflowExecutionRequest="
+          + startWorkflowExecutionRequest
+          + ", scheduledEvent="
+          + scheduledEvent
+          + ", activityTask="
+          + activityTask
+          + ", store="
+          + store
+          + ", scheduledEventId="
+          + scheduledEventId
+          + ", startedEventId="
+          + startedEventId
+          + ", startedEvent="
+          + startedEvent
+          + ", heartbeatDetails="
+          + heartbeatDetails
+          + ", lastHeartbeatTime="
+          + lastHeartbeatTime
+          + ", retryState="
+          + retryState
+          + ", nextBackoffIntervalSeconds="
+          + nextBackoffIntervalSeconds
+          + '}';
+    }
   }
 
   static final class SignalExternalData {
     long initiatedEventId = NO_EVENT_ID;
     public SignalExternalWorkflowExecutionInitiatedEventAttributes initiatedEvent;
+
+    @Override
+    public String toString() {
+      return "SignalExternalData{"
+          + "initiatedEventId="
+          + initiatedEventId
+          + ", initiatedEvent="
+          + initiatedEvent
+          + '}';
+    }
   }
 
   static final class CancelExternalData {
     long initiatedEventId = NO_EVENT_ID;
     public RequestCancelExternalWorkflowExecutionInitiatedEventAttributes initiatedEvent;
+
+    @Override
+    public String toString() {
+      return "CancelExternalData{"
+          + "initiatedEventId="
+          + initiatedEventId
+          + ", initiatedEvent="
+          + initiatedEvent
+          + '}';
+    }
   }
 
   static final class ChildWorkflowData {
@@ -224,12 +310,37 @@ class StateMachines {
     public ChildWorkflowData(TestWorkflowService service) {
       this.service = service;
     }
+
+    @Override
+    public String toString() {
+      return "ChildWorkflowData{"
+          + "service="
+          + service
+          + ", initiatedEvent="
+          + initiatedEvent
+          + ", initiatedEventId="
+          + initiatedEventId
+          + ", startedEventId="
+          + startedEventId
+          + ", execution="
+          + execution
+          + '}';
+    }
   }
 
   static final class TimerData {
-
     TimerStartedEventAttributes startedEvent;
     public long startedEventId;
+
+    @Override
+    public String toString() {
+      return "TimerData{"
+          + "startedEvent="
+          + startedEvent
+          + ", startedEventId="
+          + startedEventId
+          + '}';
+    }
   }
 
   static StateMachine<WorkflowData> newWorkflowStateMachine(WorkflowData data) {

--- a/src/main/java/io/temporal/workflow/QueryMethod.java
+++ b/src/main/java/io/temporal/workflow/QueryMethod.java
@@ -28,10 +28,18 @@ import java.lang.annotation.Target;
  * Indicates that the method is a query method. Query method can be used to query a workflow state
  * by external process at any time during its execution. This annotation applies only to workflow
  * interface methods.
+ *
+ * <p>Query methods must never change any workflow state including starting activities or block
+ * threads in any way.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface QueryMethod {
-  /** Name of the query type. Default is {short class name}::{method name} */
+  /**
+   * Name of the query type. Default is method name.
+   *
+   * <p>Be careful about names that contain special characters. These names can be used as metric
+   * tags. And systems like prometheus ignore metrics which have tags with unsupported characters.
+   */
   String name() default "";
 }

--- a/src/main/java/io/temporal/workflow/SignalMethod.java
+++ b/src/main/java/io/temporal/workflow/SignalMethod.java
@@ -31,6 +31,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface SignalMethod {
-  /** Name of the signal type. Default is {short class name}::{method name}. */
+  /**
+   * Name of the signal type. Default is method name.
+   *
+   * <p>Be careful about names that contain special characters. These names can be used as metric
+   * tags. And systems like prometheus ignore metrics which have tags with unsupported characters.
+   */
   String name() default "";
 }

--- a/src/main/java/io/temporal/workflow/WorkflowMethod.java
+++ b/src/main/java/io/temporal/workflow/WorkflowMethod.java
@@ -34,7 +34,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface WorkflowMethod {
-  /** Name of the workflow type. Default is {short class name}::{method name} */
+  /** Name of the workflow type. Default is {short class name} */
   String name() default "";
 
   /**

--- a/src/test/java/io/temporal/internal/sync/POJOActivityMetadataTest.java
+++ b/src/test/java/io/temporal/internal/sync/POJOActivityMetadataTest.java
@@ -41,7 +41,7 @@ public class POJOActivityMetadataTest {
     void bb();
   }
 
-  @ActivityInterface
+  @ActivityInterface(namePrefix = "C_")
   interface C extends B, A {
     void c();
 
@@ -158,10 +158,9 @@ public class POJOActivityMetadataTest {
     expected.add("C_a");
     expected.add("C_b");
     expected.add("C_c");
-    expected.add("D_d");
-    expected.add("E_a");
-    expected.add("E_b");
-    expected.add("E_b");
+    expected.add("d");
+    expected.add("a");
+    expected.add("b");
 
     POJOActivityImplMetadata dMetadata = POJOActivityImplMetadata.newInstance(DImpl.class);
     Set<String> dTypes = dMetadata.getActivityTypes();
@@ -195,10 +194,9 @@ public class POJOActivityMetadataTest {
     expected.add("C_a");
     expected.add("C_b");
     expected.add("C_c");
-    expected.add("D_d");
-    expected.add("E_a");
-    expected.add("E_b");
-    expected.add("E_b");
+    expected.add("d");
+    expected.add("a");
+    expected.add("b");
 
     POJOActivityInterfaceMetadata dMetadata = POJOActivityInterfaceMetadata.newInstance(D.class);
     Method c = C.class.getDeclaredMethod("c");

--- a/src/test/java/io/temporal/internal/sync/POJOWorkflowMetadataTest.java
+++ b/src/test/java/io/temporal/internal/sync/POJOWorkflowMetadataTest.java
@@ -169,14 +169,12 @@ public class POJOWorkflowMetadataTest {
     wExpected.add("AM_E_bb");
 
     Set<String> qExpected = new HashSet<>();
-    qExpected.add("C_b");
-    qExpected.add("E_b");
+    qExpected.add("b");
 
     Set<String> sExpected = new HashSet<>();
-    sExpected.add("C_a");
-    sExpected.add("C_c");
-    sExpected.add("D_d");
-    sExpected.add("E_a");
+    sExpected.add("a");
+    sExpected.add("c");
+    sExpected.add("d");
 
     POJOWorkflowImplMetadata dMetadata = POJOWorkflowImplMetadata.newInstance(DImpl.class);
     Set<String> wTypes = dMetadata.getWorkflowTypes();
@@ -222,6 +220,6 @@ public class POJOWorkflowMetadataTest {
     Method c = C.class.getDeclaredMethod("c");
     POJOWorkflowMethodMetadata cMethod = dMetadata.getMethodMetadata(c);
     assertEquals(c, cMethod.getWorkflowMethod());
-    assertEquals("C_c", cMethod.getName());
+    assertEquals("c", cMethod.getName());
   }
 }

--- a/src/test/java/io/temporal/internal/testing/ActivityTestingTest.java
+++ b/src/test/java/io/temporal/internal/testing/ActivityTestingTest.java
@@ -65,7 +65,7 @@ public class ActivityTestingTest {
     testEnvironment.registerActivitiesImplementations(new ActivityImpl());
     TestActivity activity = testEnvironment.newActivityStub(TestActivity.class);
     String result = activity.activity1("input1");
-    assertEquals("TestActivity_activity1-input1", result);
+    assertEquals("activity1-input1", result);
   }
 
   private static class AngryActivityImpl implements TestActivity {
@@ -84,7 +84,7 @@ public class ActivityTestingTest {
       activity.activity1("input1");
       fail("unreachable");
     } catch (ActivityFailureException e) {
-      assertTrue(e.getMessage().contains("TestActivity_activity1"));
+      assertTrue(e.getMessage().contains("activity1"));
       assertTrue(e.getCause() instanceof IOException);
       assertEquals("simulated", e.getCause().getMessage());
     }
@@ -266,7 +266,7 @@ public class ActivityTestingTest {
     void c();
   }
 
-  @ActivityInterface
+  @ActivityInterface(namePrefix = "D_")
   public interface D extends A {
     void d();
   }
@@ -410,7 +410,7 @@ public class ActivityTestingTest {
     try {
       testEnvironment.registerActivitiesImplementations(dImpl, eImpl);
     } catch (IllegalArgumentException e) {
-      assertTrue(e.getMessage().contains("D_a"));
+      assertTrue(e.getMessage().contains("a"));
       assertTrue(e.getMessage().contains("already registered"));
     }
   }

--- a/src/test/java/io/temporal/internal/testing/WorkflowTestingTest.java
+++ b/src/test/java/io/temporal/internal/testing/WorkflowTestingTest.java
@@ -139,7 +139,7 @@ public class WorkflowTestingTest {
     WorkflowClient client = testEnvironment.getWorkflowClient();
     TestWorkflow workflow = client.newWorkflowStub(TestWorkflow.class);
     String result = workflow.workflow1("input1");
-    assertEquals("TestWorkflow_workflow1-input1", result);
+    assertEquals("TestWorkflow-input1", result);
   }
 
   public static class FailingWorkflowImpl implements TestWorkflow {
@@ -164,7 +164,7 @@ public class WorkflowTestingTest {
       workflow.workflow1("input1");
       fail("unreacheable");
     } catch (WorkflowException e) {
-      assertEquals("TestWorkflow_workflow1-input1", e.getCause().getMessage());
+      assertEquals("TestWorkflow-input1", e.getCause().getMessage());
     }
   }
 
@@ -204,7 +204,7 @@ public class WorkflowTestingTest {
     WorkflowClient client = testEnvironment.getWorkflowClient();
     TestWorkflow workflow = client.newWorkflowStub(TestWorkflow.class);
     String result = workflow.workflow1("input1");
-    assertEquals("TestActivity_activity1-input1", result);
+    assertEquals("activity1-input1", result);
   }
 
   private static class FailingActivityImpl implements TestActivity {
@@ -227,7 +227,7 @@ public class WorkflowTestingTest {
       workflow.workflow1("input1");
       fail("unreacheable");
     } catch (WorkflowException e) {
-      assertEquals("TestActivity_activity1-input1", e.getCause().getCause().getMessage());
+      assertEquals("activity1-input1", e.getCause().getCause().getMessage());
     }
   }
 
@@ -399,7 +399,7 @@ public class WorkflowTestingTest {
     TestWorkflow workflow = client.newWorkflowStub(TestWorkflow.class);
     long start = testEnvironment.currentTimeMillis();
     String result = workflow.workflow1("input1");
-    assertEquals("TestWorkflow_workflow1-input1", result);
+    assertEquals("TestWorkflow-input1", result);
     assertTrue(testEnvironment.currentTimeMillis() - start >= Duration.ofHours(2).toMillis());
   }
 
@@ -707,11 +707,9 @@ public class WorkflowTestingTest {
       List<WorkflowExecutionInfo> executions = listResponse.getExecutionsList();
       assertEquals(2, executions.size());
       String name0 = executions.get(0).getType().getName();
-      assertTrue(
-          name0, name0.equals("ParentWorkflow_workflow") || name0.equals("ChildWorkflow_workflow"));
+      assertTrue(name0, name0.equals("ParentWorkflow") || name0.equals("ChildWorkflow"));
       String name1 = executions.get(0).getType().getName();
-      assertTrue(
-          name1, name1.equals("ParentWorkflow_workflow") || name1.equals("ChildWorkflow_workflow"));
+      assertTrue(name1, name1.equals("ParentWorkflow") || name1.equals("ChildWorkflow"));
 
       try {
         result.get();
@@ -735,11 +733,9 @@ public class WorkflowTestingTest {
     List<WorkflowExecutionInfo> executions = listResponse.getExecutionsList();
     assertEquals(2, executions.size());
     String name0 = executions.get(0).getType().getName();
-    assertTrue(
-        name0, name0.equals("ParentWorkflow_workflow") || name0.equals("ChildWorkflow_workflow"));
+    assertTrue(name0, name0.equals("ParentWorkflow") || name0.equals("ChildWorkflow"));
     String name1 = executions.get(0).getType().getName();
-    assertTrue(
-        name1, name1.equals("ParentWorkflow_workflow") || name1.equals("ChildWorkflow_workflow"));
+    assertTrue(name1, name1.equals("ParentWorkflow") || name1.equals("ChildWorkflow"));
   }
 
   @Test

--- a/src/test/java/io/temporal/worker/WorkerStressTests.java
+++ b/src/test/java/io/temporal/worker/WorkerStressTests.java
@@ -99,9 +99,7 @@ public class WorkerStressTests {
             .setTaskStartToCloseTimeout(Duration.ofSeconds(30))
             .build();
     WorkflowStub workflow =
-        wrapper
-            .getWorkflowClient()
-            .newUntypedWorkflowStub("ActivitiesWorkflow_execute", workflowOptions);
+        wrapper.getWorkflowClient().newUntypedWorkflowStub("ActivitiesWorkflow", workflowOptions);
 
     // Act
     // This will yeild around 10000 events which is above the page limit returned by the server.
@@ -140,9 +138,7 @@ public class WorkerStressTests {
             .setTaskStartToCloseTimeout(Duration.ofSeconds(30))
             .build();
     WorkflowStub workflow =
-        wrapper
-            .getWorkflowClient()
-            .newUntypedWorkflowStub("ActivitiesWorkflow_execute", workflowOptions);
+        wrapper.getWorkflowClient().newUntypedWorkflowStub("ActivitiesWorkflow", workflowOptions);
 
     // Act
     WorkflowParams w = new WorkflowParams();
@@ -160,9 +156,7 @@ public class WorkerStressTests {
 
     // Start a second workflow and kick the previous one out
     WorkflowStub workflow2 =
-        wrapper
-            .getWorkflowClient()
-            .newUntypedWorkflowStub("ActivitiesWorkflow_execute", workflowOptions);
+        wrapper.getWorkflowClient().newUntypedWorkflowStub("ActivitiesWorkflow", workflowOptions);
     w.ConcurrentCount = 1;
     workflow2.start(w);
     assertNotNull("I'm done.", workflow2.getResult(String.class));

--- a/src/test/java/io/temporal/workflow/MetricsTest.java
+++ b/src/test/java/io/temporal/workflow/MetricsTest.java
@@ -271,8 +271,8 @@ public class MetricsTest {
         new ImmutableMap.Builder<String, String>(3)
             .put(MetricsTag.NAMESPACE, WorkflowTest.NAMESPACE)
             .put(MetricsTag.TASK_LIST, taskList)
-            .put(MetricsTag.ACTIVITY_TYPE, "TestActivity_runActivity")
-            .put(MetricsTag.WORKFLOW_TYPE, "TestWorkflow_execute")
+            .put(MetricsTag.ACTIVITY_TYPE, "runActivity")
+            .put(MetricsTag.WORKFLOW_TYPE, "TestWorkflow")
             .build();
     verify(reporter, times(1))
         .reportCounter("temporal-activity-task-completed", activityCompletionTags, 1);

--- a/src/test/java/io/temporal/workflow/WorkflowTest.java
+++ b/src/test/java/io/temporal/workflow/WorkflowTest.java
@@ -5169,7 +5169,7 @@ public class WorkflowTest {
     WorkflowOptions options =
         WorkflowOptions.newBuilder()
             .setExecutionStartToCloseTimeout(Duration.ofMinutes(5))
-            .setTaskStartToCloseTimeout(Duration.ofSeconds(5))
+            .setTaskStartToCloseTimeout(Duration.ofSeconds(20))
             .setTaskList(taskList)
             .build();
     TestWorkflow1 workflowStub = workflowClient.newWorkflowStub(TestWorkflow1.class, options);

--- a/src/test/java/io/temporal/workflow/WorkflowTest.java
+++ b/src/test/java/io/temporal/workflow/WorkflowTest.java
@@ -438,8 +438,8 @@ public class WorkflowTest {
     tracer.setExpected(
         "interceptExecuteWorkflow " + UUID_REGEXP,
         "sleep PT2S",
-        "executeActivity TestActivities_activityWithDelay",
-        "executeActivity TestActivities_activity2");
+        "executeActivity activityWithDelay",
+        "executeActivity activity2");
   }
 
   @WorkflowInterface
@@ -731,7 +731,7 @@ public class WorkflowTest {
                       .build())
               .build();
       ActivityStub activities = Workflow.newUntypedActivityStub(options);
-      activities.execute("TestActivities_throwIO", Void.class);
+      activities.execute("throwIO", Void.class);
       return "ignored";
     }
   }
@@ -950,7 +950,7 @@ public class WorkflowTest {
     startWorkerFor(TestSyncWorkflowImpl.class);
     WorkflowStub workflowStub =
         workflowClient.newUntypedWorkflowStub(
-            "TestWorkflow1_execute", newWorkflowOptionsBuilder(taskList).build());
+            "TestWorkflow1", newWorkflowOptionsBuilder(taskList).build());
     WorkflowExecution execution = workflowStub.start(taskList);
     sleep(Duration.ofMillis(500));
     String stackTrace = workflowStub.query(QUERY_TYPE_STACK_TRACE, String.class);
@@ -988,7 +988,7 @@ public class WorkflowTest {
     startWorkerFor(TestCancellationForWorkflowsWithFailedPromises.class);
     WorkflowStub client =
         workflowClient.newUntypedWorkflowStub(
-            "TestWorkflow1_execute", newWorkflowOptionsBuilder(taskList).build());
+            "TestWorkflow1", newWorkflowOptionsBuilder(taskList).build());
     client.start(taskList);
     client.cancel();
 
@@ -1004,7 +1004,7 @@ public class WorkflowTest {
     startWorkerFor(TestSyncWorkflowImpl.class);
     WorkflowStub client =
         workflowClient.newUntypedWorkflowStub(
-            "TestWorkflow1_execute", newWorkflowOptionsBuilder(taskList).build());
+            "TestWorkflow1", newWorkflowOptionsBuilder(taskList).build());
     client.start(taskList);
     client.cancel();
     try {
@@ -1029,7 +1029,7 @@ public class WorkflowTest {
     startWorkerFor(TestCancellationScopePromise.class);
     WorkflowStub client =
         workflowClient.newUntypedWorkflowStub(
-            "TestWorkflow1_execute", newWorkflowOptionsBuilder(taskList).build());
+            "TestWorkflow1", newWorkflowOptionsBuilder(taskList).build());
     client.start(taskList);
     client.cancel();
     try {
@@ -1079,7 +1079,7 @@ public class WorkflowTest {
     startWorkerFor(TestDetachedCancellationScope.class);
     WorkflowStub client =
         workflowClient.newUntypedWorkflowStub(
-            "TestWorkflow1_execute", newWorkflowOptionsBuilder(taskList).build());
+            "TestWorkflow1", newWorkflowOptionsBuilder(taskList).build());
     client.start(taskList);
     sleep(Duration.ofMillis(500)); // To let activityWithDelay start.
     client.cancel();
@@ -1235,7 +1235,7 @@ public class WorkflowTest {
     startWorkerFor(TestParentWorkflowImpl.class, TestChildWorkflowImpl.class);
     WorkflowStub client =
         workflowClient.newUntypedWorkflowStub(
-            "TestWorkflow_execute", newWorkflowOptionsBuilder(taskList).build());
+            "TestWorkflow", newWorkflowOptionsBuilder(taskList).build());
     WorkflowExecution execution =
         client.start(ChildWorkflowCancellationType.WAIT_CANCELLATION_REQUESTED);
     waitForOKQuery(client);
@@ -1272,7 +1272,7 @@ public class WorkflowTest {
     startWorkerFor(TestParentWorkflowImpl.class, TestChildWorkflowImpl.class);
     WorkflowStub client =
         workflowClient.newUntypedWorkflowStub(
-            "TestWorkflow_execute", newWorkflowOptionsBuilder(taskList).build());
+            "TestWorkflow", newWorkflowOptionsBuilder(taskList).build());
     WorkflowExecution execution =
         client.start(ChildWorkflowCancellationType.WAIT_CANCELLATION_COMPLETED);
     waitForOKQuery(client);
@@ -1304,7 +1304,7 @@ public class WorkflowTest {
     startWorkerFor(TestParentWorkflowImpl.class, TestChildWorkflowImpl.class);
     WorkflowStub client =
         workflowClient.newUntypedWorkflowStub(
-            "TestWorkflow_execute", newWorkflowOptionsBuilder(taskList).build());
+            "TestWorkflow", newWorkflowOptionsBuilder(taskList).build());
     WorkflowExecution execution = client.start(ChildWorkflowCancellationType.ABANDON);
     waitForOKQuery(client);
     client.cancel();
@@ -1335,7 +1335,7 @@ public class WorkflowTest {
     startWorkerFor(TestParentWorkflowImpl.class, TestChildWorkflowImpl.class);
     WorkflowStub client =
         workflowClient.newUntypedWorkflowStub(
-            "TestWorkflow_execute", newWorkflowOptionsBuilder(taskList).build());
+            "TestWorkflow", newWorkflowOptionsBuilder(taskList).build());
     WorkflowExecution execution = client.start(ChildWorkflowCancellationType.TRY_CANCEL);
     waitForOKQuery(client);
     client.cancel();
@@ -1480,8 +1480,7 @@ public class WorkflowTest {
     @Override
     public String execute(String taskList) {
       ActivityStub testActivities = Workflow.newUntypedActivityStub(newActivityOptions2());
-      Promise<String> a =
-          Async.function(testActivities::<String>execute, "TestActivities_activity", String.class);
+      Promise<String> a = Async.function(testActivities::<String>execute, "activity", String.class);
       Promise<String> a1 =
           Async.function(
               testActivities::<String>execute,
@@ -1489,35 +1488,22 @@ public class WorkflowTest {
               String.class,
               "1"); // name overridden in annotation
       Promise<String> a2 =
-          Async.function(
-              testActivities::<String>execute, "TestActivities_activity2", String.class, "1", 2);
+          Async.function(testActivities::<String>execute, "activity2", String.class, "1", 2);
       Promise<String> a3 =
-          Async.function(
-              testActivities::<String>execute, "TestActivities_activity3", String.class, "1", 2, 3);
+          Async.function(testActivities::<String>execute, "activity3", String.class, "1", 2, 3);
       Promise<String> a4 =
-          Async.function(
-              testActivities::<String>execute,
-              "TestActivities_activity4",
-              String.class,
-              "1",
-              2,
-              3,
-              4);
+          Async.function(testActivities::<String>execute, "activity4", String.class, "1", 2, 3, 4);
       assertEquals("activity", a.get());
       assertEquals("1", a1.get());
       assertEquals("12", a2.get());
       assertEquals("123", a3.get());
       assertEquals("1234", a4.get());
 
-      Async.procedure(testActivities::<Void>execute, "TestActivities_proc", Void.class).get();
-      Async.procedure(testActivities::<Void>execute, "TestActivities_proc1", Void.class, "1").get();
-      Async.procedure(testActivities::<Void>execute, "TestActivities_proc2", Void.class, "1", 2)
-          .get();
-      Async.procedure(testActivities::<Void>execute, "TestActivities_proc3", Void.class, "1", 2, 3)
-          .get();
-      Async.procedure(
-              testActivities::<Void>execute, "TestActivities_proc4", Void.class, "1", 2, 3, 4)
-          .get();
+      Async.procedure(testActivities::<Void>execute, "proc", Void.class).get();
+      Async.procedure(testActivities::<Void>execute, "proc1", Void.class, "1").get();
+      Async.procedure(testActivities::<Void>execute, "proc2", Void.class, "1", 2).get();
+      Async.procedure(testActivities::<Void>execute, "proc3", Void.class, "1", 2, 3).get();
+      Async.procedure(testActivities::<Void>execute, "proc4", Void.class, "1", 2, 3, 4).get();
       return "workflow";
     }
   }
@@ -1542,20 +1528,16 @@ public class WorkflowTest {
     @Override
     public String execute(String taskList) {
       ActivityStub testActivities = Workflow.newUntypedActivityStub(newActivityOptions2());
-      Promise<String> a = testActivities.executeAsync("TestActivities_activity", String.class);
+      Promise<String> a = testActivities.executeAsync("activity", String.class);
       Promise<String> a1 =
           testActivities.executeAsync(
               "customActivity1", String.class, "1"); // name overridden in annotation
-      Promise<String> a2 =
-          testActivities.executeAsync("TestActivities_activity2", String.class, "1", 2);
-      Promise<String> a3 =
-          testActivities.executeAsync("TestActivities_activity3", String.class, "1", 2, 3);
-      Promise<String> a4 =
-          testActivities.executeAsync("TestActivities_activity4", String.class, "1", 2, 3, 4);
-      Promise<String> a5 =
-          testActivities.executeAsync("TestActivities_activity5", String.class, "1", 2, 3, 4, 5);
+      Promise<String> a2 = testActivities.executeAsync("activity2", String.class, "1", 2);
+      Promise<String> a3 = testActivities.executeAsync("activity3", String.class, "1", 2, 3);
+      Promise<String> a4 = testActivities.executeAsync("activity4", String.class, "1", 2, 3, 4);
+      Promise<String> a5 = testActivities.executeAsync("activity5", String.class, "1", 2, 3, 4, 5);
       Promise<String> a6 =
-          testActivities.executeAsync("TestActivities_activity6", String.class, "1", 2, 3, 4, 5, 6);
+          testActivities.executeAsync("activity6", String.class, "1", 2, 3, 4, 5, 6);
       assertEquals("activity", a.get());
       assertEquals("1", a1.get());
       assertEquals("12", a2.get());
@@ -1564,13 +1546,13 @@ public class WorkflowTest {
       assertEquals("12345", a5.get());
       assertEquals("123456", a6.get());
 
-      testActivities.executeAsync("TestActivities_proc", Void.class).get();
-      testActivities.executeAsync("TestActivities_proc1", Void.class, "1").get();
-      testActivities.executeAsync("TestActivities_proc2", Void.class, "1", 2).get();
-      testActivities.executeAsync("TestActivities_proc3", Void.class, "1", 2, 3).get();
-      testActivities.executeAsync("TestActivities_proc4", Void.class, "1", 2, 3, 4).get();
-      testActivities.executeAsync("TestActivities_proc5", Void.class, "1", 2, 3, 4, 5).get();
-      testActivities.executeAsync("TestActivities_proc6", Void.class, "1", 2, 3, 4, 5, 6).get();
+      testActivities.executeAsync("proc", Void.class).get();
+      testActivities.executeAsync("proc1", Void.class, "1").get();
+      testActivities.executeAsync("proc2", Void.class, "1", 2).get();
+      testActivities.executeAsync("proc3", Void.class, "1", 2, 3).get();
+      testActivities.executeAsync("proc4", Void.class, "1", 2, 3, 4).get();
+      testActivities.executeAsync("proc5", Void.class, "1", 2, 3, 4, 5).get();
+      testActivities.executeAsync("proc6", Void.class, "1", 2, 3, 4, 5, 6).get();
       return "workflow";
     }
   }
@@ -2002,58 +1984,47 @@ public class WorkflowTest {
       ChildWorkflowOptions workflowOptions =
           ChildWorkflowOptions.newBuilder().setTaskList(taskList).build();
       ChildWorkflowStub stubF =
-          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc_func", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc", workflowOptions);
       assertEquals("func", stubF.execute(String.class));
       // Workflow type overridden through the @WorkflowMethod.name
       ChildWorkflowStub stubF1 = Workflow.newUntypedChildWorkflowStub("func1", workflowOptions);
       assertEquals("1", stubF1.execute(String.class, "1"));
       ChildWorkflowStub stubF2 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc2_func2", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc2", workflowOptions);
       assertEquals("12", stubF2.execute(String.class, "1", 2));
       ChildWorkflowStub stubF3 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc3_func3", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc3", workflowOptions);
       assertEquals("123", stubF3.execute(String.class, "1", 2, 3));
       ChildWorkflowStub stubF4 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc4_func4", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc4", workflowOptions);
       assertEquals("1234", stubF4.execute(String.class, "1", 2, 3, 4));
       ChildWorkflowStub stubF5 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc5_func5", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc5", workflowOptions);
       assertEquals("12345", stubF5.execute(String.class, "1", 2, 3, 4, 5));
       ChildWorkflowStub stubF6 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc6_func6", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc6", workflowOptions);
       assertEquals("123456", stubF6.execute(String.class, "1", 2, 3, 4, 5, 6));
 
       ChildWorkflowStub stubP =
-          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc_proc", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc", workflowOptions);
       stubP.execute(Void.class);
       ChildWorkflowStub stubP1 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc1_proc1", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc1", workflowOptions);
       stubP1.execute(Void.class, "1");
       ChildWorkflowStub stubP2 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc2_proc2", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc2", workflowOptions);
       stubP2.execute(Void.class, "1", 2);
       ChildWorkflowStub stubP3 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc3_proc3", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc3", workflowOptions);
       stubP3.execute(Void.class, "1", 2, 3);
       ChildWorkflowStub stubP4 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc4_proc4", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc4", workflowOptions);
       stubP4.execute(Void.class, "1", 2, 3, 4);
       ChildWorkflowStub stubP5 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc5_proc5", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc5", workflowOptions);
       stubP5.execute(Void.class, "1", 2, 3, 4, 5);
       ChildWorkflowStub stubP6 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc6_proc6", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc6", workflowOptions);
       stubP6.execute(Void.class, "1", 2, 3, 4, 5, 6);
       return null;
     }
@@ -2078,58 +2049,47 @@ public class WorkflowTest {
       ChildWorkflowOptions workflowOptions =
           ChildWorkflowOptions.newBuilder().setTaskList(taskList).build();
       ChildWorkflowStub stubF =
-          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc_func", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc", workflowOptions);
       assertEquals("func", stubF.executeAsync(String.class).get());
       // Workflow type overridden through the @WorkflowMethod.name
       ChildWorkflowStub stubF1 = Workflow.newUntypedChildWorkflowStub("func1", workflowOptions);
       assertEquals("1", stubF1.executeAsync(String.class, "1").get());
       ChildWorkflowStub stubF2 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc2_func2", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc2", workflowOptions);
       assertEquals("12", stubF2.executeAsync(String.class, "1", 2).get());
       ChildWorkflowStub stubF3 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc3_func3", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc3", workflowOptions);
       assertEquals("123", stubF3.executeAsync(String.class, "1", 2, 3).get());
       ChildWorkflowStub stubF4 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc4_func4", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc4", workflowOptions);
       assertEquals("1234", stubF4.executeAsync(String.class, "1", 2, 3, 4).get());
       ChildWorkflowStub stubF5 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc5_func5", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc5", workflowOptions);
       assertEquals("12345", stubF5.executeAsync(String.class, "1", 2, 3, 4, 5).get());
       ChildWorkflowStub stubF6 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc6_func6", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc6", workflowOptions);
       assertEquals("123456", stubF6.executeAsync(String.class, "1", 2, 3, 4, 5, 6).get());
 
       ChildWorkflowStub stubP =
-          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc_proc", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc", workflowOptions);
       stubP.executeAsync(Void.class).get();
       ChildWorkflowStub stubP1 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc1_proc1", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc1", workflowOptions);
       stubP1.executeAsync(Void.class, "1").get();
       ChildWorkflowStub stubP2 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc2_proc2", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc2", workflowOptions);
       stubP2.executeAsync(Void.class, "1", 2).get();
       ChildWorkflowStub stubP3 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc3_proc3", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc3", workflowOptions);
       stubP3.executeAsync(Void.class, "1", 2, 3).get();
       ChildWorkflowStub stubP4 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc4_proc4", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc4", workflowOptions);
       stubP4.executeAsync(Void.class, "1", 2, 3, 4).get();
       ChildWorkflowStub stubP5 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc5_proc5", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc5", workflowOptions);
       stubP5.executeAsync(Void.class, "1", 2, 3, 4, 5).get();
       ChildWorkflowStub stubP6 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc6_proc6", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc6", workflowOptions);
       stubP6.executeAsync(Void.class, "1", 2, 3, 4, 5, 6).get();
       return null;
     }
@@ -2154,52 +2114,43 @@ public class WorkflowTest {
       ChildWorkflowOptions workflowOptions =
           ChildWorkflowOptions.newBuilder().setTaskList(taskList).build();
       ChildWorkflowStub stubF =
-          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc_func", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc", workflowOptions);
       assertEquals("func", Async.function(stubF::<String>execute, String.class).get());
       // Workflow type overridden through the @WorkflowMethod.name
       ChildWorkflowStub stubF1 = Workflow.newUntypedChildWorkflowStub("func1", workflowOptions);
       assertEquals("1", Async.function(stubF1::<String>execute, String.class, "1").get());
       ChildWorkflowStub stubF2 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc2_func2", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc2", workflowOptions);
       assertEquals("12", Async.function(stubF2::<String>execute, String.class, "1", 2).get());
       ChildWorkflowStub stubF3 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc3_func3", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc3", workflowOptions);
       assertEquals("123", Async.function(stubF3::<String>execute, String.class, "1", 2, 3).get());
       ChildWorkflowStub stubF4 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc4_func4", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc4", workflowOptions);
       assertEquals(
           "1234", Async.function(stubF4::<String>execute, String.class, "1", 2, 3, 4).get());
       ChildWorkflowStub stubF5 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsFunc5_func5", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc5", workflowOptions);
       assertEquals(
           "12345", Async.function(stubF5::<String>execute, String.class, "1", 2, 3, 4, 5).get());
 
       ChildWorkflowStub stubP =
-          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc_proc", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc", workflowOptions);
       Async.procedure(stubP::<Void>execute, Void.class).get();
       ChildWorkflowStub stubP1 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc1_proc1", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc1", workflowOptions);
       Async.procedure(stubP1::<Void>execute, Void.class, "1").get();
       ChildWorkflowStub stubP2 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc2_proc2", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc2", workflowOptions);
       Async.procedure(stubP2::<Void>execute, Void.class, "1", 2).get();
       ChildWorkflowStub stubP3 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc3_proc3", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc3", workflowOptions);
       Async.procedure(stubP3::<Void>execute, Void.class, "1", 2, 3).get();
       ChildWorkflowStub stubP4 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc4_proc4", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc4", workflowOptions);
       Async.procedure(stubP4::<Void>execute, Void.class, "1", 2, 3, 4).get();
       ChildWorkflowStub stubP5 =
-          Workflow.newUntypedChildWorkflowStub(
-              "TestMultiargsWorkflowsProc5_proc5", workflowOptions);
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc5", workflowOptions);
       Async.procedure(stubP5::<Void>execute, Void.class, "1", 2, 3, 4, 5).get();
       return null;
     }
@@ -2436,7 +2387,7 @@ public class WorkflowTest {
         return "ignored";
       } catch (ActivityFailureException e) {
         try {
-          assertTrue(e.getMessage().contains("TestActivities_throwIO"));
+          assertTrue(e.getMessage().contains("throwIO"));
           assertTrue(e.getCause() instanceof IOException);
           assertEquals("simulated IO problem", e.getCause().getMessage());
         } catch (AssertionError ae) {
@@ -2466,7 +2417,7 @@ public class WorkflowTest {
       } catch (RuntimeException e) {
         try {
           assertNoEmptyStacks(e);
-          assertTrue(e.getMessage().contains("TestWorkflow1_execute"));
+          assertTrue(e.getMessage().contains("TestWorkflow1"));
           assertTrue(e instanceof ChildWorkflowException);
           assertTrue(e.getCause() instanceof NumberFormatException);
           assertTrue(e.getCause().getCause() instanceof ActivityFailureException);
@@ -2524,7 +2475,7 @@ public class WorkflowTest {
       assertNoEmptyStacks(e);
       // Uncomment to see the actual trace.
       //            e.printStackTrace();
-      assertTrue(e.getMessage(), e.getMessage().contains("TestExceptionPropagation_execute"));
+      assertTrue(e.getMessage(), e.getMessage().contains("TestExceptionPropagation"));
       assertTrue(e.getStackTrace().length > 0);
       assertTrue(e.getCause() instanceof FileNotFoundException);
       assertTrue(e.getCause().getCause() instanceof ChildWorkflowException);
@@ -2743,7 +2694,7 @@ public class WorkflowTest {
   @Test
   public void testSignalUntyped() {
     startWorkerFor(TestSignalWorkflowImpl.class);
-    String workflowType = QueryableWorkflow.class.getSimpleName() + "_execute";
+    String workflowType = QueryableWorkflow.class.getSimpleName();
     AtomicReference<WorkflowExecution> execution = new AtomicReference<>();
     WorkflowStub client =
         workflowClient.newUntypedWorkflowStub(
@@ -2753,14 +2704,14 @@ public class WorkflowTest {
     registerDelayedCallback(
         Duration.ofSeconds(1),
         () -> {
-          assertEquals("initial", client.query("QueryableWorkflow_getState", String.class));
+          assertEquals("initial", client.query("getState", String.class));
           client.signal("testSignal", "Hello ");
           sleep(Duration.ofMillis(500));
-          while (!"Hello ".equals(client.query("QueryableWorkflow_getState", String.class))) {}
-          assertEquals("Hello ", client.query("QueryableWorkflow_getState", String.class));
+          while (!"Hello ".equals(client.query("getState", String.class))) {}
+          assertEquals("Hello ", client.query("getState", String.class));
           client.signal("testSignal", "World!");
-          while (!"World!".equals(client.query("QueryableWorkflow_getState", String.class))) {}
-          assertEquals("World!", client.query("QueryableWorkflow_getState", String.class));
+          while (!"World!".equals(client.query("getState", String.class))) {}
+          assertEquals("World!", client.query("getState", String.class));
           assertEquals(
               "Hello World!",
               workflowClient
@@ -2769,9 +2720,9 @@ public class WorkflowTest {
         });
     execution.set(client.start());
     assertEquals("Hello World!", client.getResult(String.class));
-    assertEquals("World!", client.query("QueryableWorkflow_getState", String.class));
+    assertEquals("World!", client.query("getState", String.class));
     QueryResponse<String> queryResponse =
-        client.query("QueryableWorkflow_getState", String.class, QueryRejectCondition.NotOpen);
+        client.query("getState", String.class, QueryRejectCondition.NotOpen);
     assertNull(queryResponse.getResult());
     assertEquals(
         execution.toString(),
@@ -3194,7 +3145,7 @@ public class WorkflowTest {
       assertTrue(e.toString(), e.getCause().getCause() instanceof UnsupportedOperationException);
       assertEquals("simulated failure", e.getCause().getCause().getMessage());
     }
-    assertEquals("TestWorkflow1_execute", lastStartedWorkflowType.get());
+    assertEquals("TestWorkflow1", lastStartedWorkflowType.get());
     assertEquals(3, angryChildActivity.getInvocationCount());
   }
 
@@ -3313,15 +3264,14 @@ public class WorkflowTest {
     tracer.setExpected(
         "interceptExecuteWorkflow " + stub.getExecution().getWorkflowId(),
         "registerSignal testSignal",
-        "executeChildWorkflow SignalingChild_execute",
+        "executeChildWorkflow SignalingChild",
         "interceptExecuteWorkflow " + UUID_REGEXP, // child
         "signalExternalWorkflow " + UUID_REGEXP + " testSignal");
   }
 
   public static class TestUntypedSignalExternalWorkflow implements TestWorkflowSignaled {
 
-    private final ChildWorkflowStub child =
-        Workflow.newUntypedChildWorkflowStub("SignalingChild_execute");
+    private final ChildWorkflowStub child = Workflow.newUntypedChildWorkflowStub("SignalingChild");
 
     private final CompletablePromise<Object> fromSignal = Workflow.newPromise();
 
@@ -3746,7 +3696,7 @@ public class WorkflowTest {
 
     WorkflowStub client =
         workflowClient.newUntypedWorkflowStub(
-            "TestWorkflowWithCronSchedule_execute",
+            "TestWorkflowWithCronSchedule",
             newWorkflowOptionsBuilder(taskList)
                 .setExecutionStartToCloseTimeout(Duration.ofHours(1))
                 .setCronSchedule("0 * * * *")
@@ -3785,7 +3735,7 @@ public class WorkflowTest {
 
     WorkflowStub client =
         workflowClient.newUntypedWorkflowStub(
-            "TestWorkflow1_execute",
+            "TestWorkflow1",
             newWorkflowOptionsBuilder(taskList)
                 .setExecutionStartToCloseTimeout(Duration.ofHours(10))
                 .build());
@@ -4448,7 +4398,7 @@ public class WorkflowTest {
     tracer.setExpected(
         "interceptExecuteWorkflow " + UUID_REGEXP,
         "getVersion",
-        "executeActivity TestActivities_activity2",
+        "executeActivity activity2",
         "getVersion",
         "executeActivity customActivity1",
         "executeActivity customActivity1",
@@ -4585,8 +4535,8 @@ public class WorkflowTest {
     tracer.setExpected(
         "interceptExecuteWorkflow " + UUID_REGEXP,
         "getVersion",
-        "executeActivity TestActivities_activity2",
-        "executeActivity TestActivities_activity");
+        "executeActivity activity2",
+        "executeActivity activity");
   }
 
   // The following test covers the scenario where getVersion call is removed before another
@@ -4622,7 +4572,7 @@ public class WorkflowTest {
         "interceptExecuteWorkflow " + UUID_REGEXP,
         "getVersion",
         "getVersion",
-        "executeActivity TestActivities_activity");
+        "executeActivity activity");
   }
 
   public static class TestVersionNotSupportedWorkflowImpl implements TestWorkflow1 {
@@ -4819,7 +4769,7 @@ public class WorkflowTest {
         "interceptExecuteWorkflow " + UUID_REGEXP,
         "sideEffect",
         "sideEffect",
-        "executeActivity TestActivities_activity2");
+        "executeActivity activity2");
   }
 
   @ActivityInterface
@@ -4959,7 +4909,7 @@ public class WorkflowTest {
       try {
         activity.execute();
       } catch (ActivityFailureException e) {
-        return e.getMessage();
+        return e.getCause().getMessage();
       }
       return "done";
     }
@@ -5005,13 +4955,13 @@ public class WorkflowTest {
                   .setScheduleToCloseTimeout(Duration.ofSeconds(5))
                   .build());
       try {
-        activity.execute("NonDeserializableArgumentsActivity_execute", Void.class, "boo");
+        activity.execute("execute", Void.class, "boo");
       } catch (ActivityFailureException e) {
         result.append(e.getCause().getClass().getSimpleName());
       }
       result.append("-");
       try {
-        localActivity.execute("NonDeserializableArgumentsActivity_execute", Void.class, "boo");
+        localActivity.execute("execute", Void.class, "boo");
       } catch (ActivityFailureException e) {
         result.append(e.getCause().getClass().getSimpleName());
       }
@@ -5172,7 +5122,7 @@ public class WorkflowTest {
         localActivities.throwIO();
       } catch (ActivityFailureException e) {
         try {
-          assertTrue(e.getMessage().contains("TestActivities_throwIO"));
+          assertTrue(e.getMessage().contains("throwIO"));
           assertTrue(e.getCause() instanceof IOException);
           assertEquals("simulated IO problem", e.getCause().getMessage());
         } catch (AssertionError ae) {
@@ -5623,12 +5573,12 @@ public class WorkflowTest {
     tracer.setExpected(
         "interceptExecuteWorkflow " + UUID_REGEXP,
         "executeActivity customActivity1",
-        "executeChildWorkflow TestMultiargsWorkflowsFunc_func",
+        "executeChildWorkflow TestMultiargsWorkflowsFunc",
         "interceptExecuteWorkflow " + UUID_REGEXP,
-        "executeActivity TestActivities_throwIO",
-        "executeChildWorkflow TestCompensationWorkflow_compensate",
+        "executeActivity throwIO",
+        "executeChildWorkflow TestCompensationWorkflow",
         "interceptExecuteWorkflow " + UUID_REGEXP,
-        "executeActivity TestActivities_activity2");
+        "executeActivity activity2");
   }
 
   @Test
@@ -5642,8 +5592,8 @@ public class WorkflowTest {
             TestSagaWorkflow.class, newWorkflowOptionsBuilder(taskList).build());
     sagaWorkflow.execute(taskList, true);
     String trace = tracer.getTrace();
-    assertTrue(trace, trace.contains("executeChildWorkflow TestCompensationWorkflow_compensate"));
-    assertTrue(trace, trace.contains("executeActivity TestActivities_activity2"));
+    assertTrue(trace, trace.contains("executeChildWorkflow TestCompensationWorkflow"));
+    assertTrue(trace, trace.contains("executeActivity activity2"));
   }
 
   public static class TestSignalExceptionWorkflowImpl implements TestWorkflowSignaled {
@@ -5749,7 +5699,7 @@ public class WorkflowTest {
     tracer.setExpected(
         "interceptExecuteWorkflow " + UUID_REGEXP,
         "upsertSearchAttributes",
-        "executeActivity TestActivities_activity");
+        "executeActivity activity");
   }
 
   public static class TestMultiargsWorkflowsFuncChild implements TestMultiargsWorkflowsFunc2 {
@@ -5941,7 +5891,7 @@ public class WorkflowTest {
       signalStub.getSignal();
       fail("unreachable"); // as not listener is not registered yet
     } catch (WorkflowQueryException e) {
-      assertTrue(e.getMessage().contains("Unknown query type: SignalQueryBase_getSignal"));
+      assertTrue(e.getMessage().contains("Unknown query type: getSignal"));
     }
     stub.register();
     while (true) {
@@ -5949,7 +5899,7 @@ public class WorkflowTest {
         assertEquals("a, b", signalStub.getSignal());
         break;
       } catch (WorkflowQueryException e) {
-        assertTrue(e.getMessage().contains("Unknown query type: SignalQueryBase_getSignal"));
+        assertTrue(e.getMessage().contains("Unknown query type: getSignal"));
       }
     }
   }

--- a/src/test/resources/resetWorkflowHistory.json
+++ b/src/test/resources/resetWorkflowHistory.json
@@ -7,7 +7,7 @@
     "taskId": 1049398,
     "workflowExecutionStartedEventAttributes": {
       "workflowType": {
-        "name": "TestWorkflow1_execute"
+        "name": "TestWorkflow1"
       },
       "taskList": {
         "name": "WorkflowTest-testWorkflowReset[Docker Sticky OFF]-2ac130cd-f7fb-48db-8c06-a7b8db8906fd"
@@ -68,7 +68,7 @@
     "activityTaskScheduledEventAttributes": {
       "activityId": "1",
       "activityType": {
-        "name": "TestActivities_activity"
+        "name": "activity"
       },
       "taskList": {
         "name": "WorkflowTest-testWorkflowReset[Docker Sticky OFF]-2ac130cd-f7fb-48db-8c06-a7b8db8906fd"
@@ -339,7 +339,7 @@
     "activityTaskScheduledEventAttributes": {
       "activityId": "5",
       "activityType": {
-        "name": "TestActivities_activity"
+        "name": "activity"
       },
       "taskList": {
         "name": "WorkflowTest-testWorkflowReset[Docker Sticky OFF]-2ac130cd-f7fb-48db-8c06-a7b8db8906fd"
@@ -529,7 +529,7 @@
     "activityTaskScheduledEventAttributes": {
       "activityId": "9",
       "activityType": {
-        "name": "TestActivities_activity"
+        "name": "activity"
       },
       "taskList": {
         "name": "WorkflowTest-testWorkflowReset[Docker Sticky OFF]-2ac130cd-f7fb-48db-8c06-a7b8db8906fd"
@@ -757,7 +757,7 @@
     "activityTaskScheduledEventAttributes": {
       "activityId": "13",
       "activityType": {
-        "name": "TestActivities_activity"
+        "name": "activity"
       },
       "taskList": {
         "name": "WorkflowTest-testWorkflowReset[Docker Sticky OFF]-2ac130cd-f7fb-48db-8c06-a7b8db8906fd"
@@ -842,7 +842,7 @@
     "activityTaskScheduledEventAttributes": {
       "activityId": "15",
       "activityType": {
-        "name": "TestActivities_activity"
+        "name": "activity"
       },
       "taskList": {
         "name": "WorkflowTest-testWorkflowReset[Docker Sticky OFF]-2ac130cd-f7fb-48db-8c06-a7b8db8906fd"
@@ -970,7 +970,7 @@
     "activityTaskScheduledEventAttributes": {
       "activityId": "17",
       "activityType": {
-        "name": "TestActivities_activity"
+        "name": "activity"
       },
       "taskList": {
         "name": "WorkflowTest-testWorkflowReset[Docker Sticky OFF]-2ac130cd-f7fb-48db-8c06-a7b8db8906fd"

--- a/src/test/resources/testAsyncActivityRetryHistory.json
+++ b/src/test/resources/testAsyncActivityRetryHistory.json
@@ -6,7 +6,7 @@
     "version": -24,
     "workflowExecutionStartedEventAttributes": {
       "workflowType": {
-        "name": "TestWorkflow1_execute"
+        "name": "TestWorkflow1"
       },
       "taskList": {
         "name": "WorkflowTest-testAsyncActivityRetry[Docker Sticky ON]-3f9e1f99-7718-4975-a8a3-c0dfdaee42f7"
@@ -72,7 +72,7 @@
     "activityTaskScheduledEventAttributes": {
       "activityId": "1",
       "activityType": {
-        "name": "TestActivities_throwIO"
+        "name": "throwIO"
       },
       "taskList": {
         "name": "WorkflowTest-testAsyncActivityRetry[Docker Sticky ON]-3f9e1f99-7718-4975-a8a3-c0dfdaee42f7"
@@ -219,7 +219,7 @@
     "activityTaskScheduledEventAttributes": {
       "activityId": "3",
       "activityType": {
-        "name": "TestActivities_throwIO"
+        "name": "throwIO"
       },
       "taskList": {
         "name": "WorkflowTest-testAsyncActivityRetry[Docker Sticky ON]-3f9e1f99-7718-4975-a8a3-c0dfdaee42f7"
@@ -366,7 +366,7 @@
     "activityTaskScheduledEventAttributes": {
       "activityId": "5",
       "activityType": {
-        "name": "TestActivities_throwIO"
+        "name": "throwIO"
       },
       "taskList": {
         "name": "WorkflowTest-testAsyncActivityRetry[Docker Sticky ON]-3f9e1f99-7718-4975-a8a3-c0dfdaee42f7"

--- a/src/test/resources/testChildWorkflowRetryHistory.json
+++ b/src/test/resources/testChildWorkflowRetryHistory.json
@@ -6,7 +6,7 @@
     "version": -24,
     "workflowExecutionStartedEventAttributes": {
       "workflowType": {
-        "name": "TestWorkflow1_execute"
+        "name": "TestWorkflow1"
       },
       "taskList": {
         "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky ON]-7f1642a9-9092-4ab1-9820-ffdf9eec95ce"

--- a/src/test/resources/testMutableSideEffectBackwardCompatibility.json
+++ b/src/test/resources/testMutableSideEffectBackwardCompatibility.json
@@ -9,7 +9,7 @@
       "version": -24,
       "workflowExecutionStartedEventAttributes": {
         "workflowType": {
-          "name": "TestWorkflow1_execute"
+          "name": "TestWorkflow1"
         },
         "taskList": {
           "name": "WorkflowTest-testMutableSideEffect[Docker Sticky ON]-53e839aa-7dab-4cb0-9e65-a73c97a53815"


### PR DESCRIPTION
Before this change the default names of workflow and activity types as well as query and signal handlers are in the form <short interface class name>_<method_name>.

These names are too long and are not user friendly. So the most users end up redefining them using annotations. This change changes the default names to:

Note that query and signal are always scoped to a specific workflow instance. So prefix in their name is not that useful. At the same time the workflow type is usually pretty unique and adding its main method name is not really necessary.

- workflow type is <short interface class name>
- query type is <method name>
- signal type is <method name>

Activity names are by default become just method name of the activity method. It is possible to add a prefix to all the activity name through ActivityInterface.namePrefix annotation parameter.