### PR TITLE
Fixed signalWithStart in the test service

### DIFF
--- a/src/main/java/io/temporal/client/WorkflowOptions.java
+++ b/src/main/java/io/temporal/client/WorkflowOptions.java
@@ -248,10 +248,6 @@ public final class WorkflowOptions {
       if (taskList == null) {
         throw new IllegalArgumentException("Required property taskList is not set");
       }
-      WorkflowIdReusePolicy policy = workflowIdReusePolicy;
-      if (policy == null) {
-        policy = WorkflowIdReusePolicy.AllowDuplicateFailedOnly;
-      }
       if (retryOptions != null) {
         if (retryOptions.getInitialInterval() == null) {
           throw new IllegalArgumentException(
@@ -265,7 +261,7 @@ public final class WorkflowOptions {
 
       return new WorkflowOptions(
           workflowId,
-          policy,
+          workflowIdReusePolicy,
           roundUpToSeconds(executionStartToCloseTimeout),
           roundUpToSeconds(
               taskStartToCloseTimeout, OptionsUtils.DEFAULT_TASK_START_TO_CLOSE_TIMEOUT),

--- a/src/main/java/io/temporal/internal/external/GenericWorkflowClientExternalImpl.java
+++ b/src/main/java/io/temporal/internal/external/GenericWorkflowClientExternalImpl.java
@@ -110,7 +110,9 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
         (int) startParameters.getExecutionStartToCloseTimeoutSeconds());
     request.setTaskStartToCloseTimeoutSeconds(
         (int) startParameters.getTaskStartToCloseTimeoutSeconds());
-    request.setWorkflowIdReusePolicy(startParameters.getWorkflowIdReusePolicy());
+    if (startParameters.getWorkflowIdReusePolicy() != null) {
+      request.setWorkflowIdReusePolicy(startParameters.getWorkflowIdReusePolicy());
+    }
     String taskList = startParameters.getTaskList();
     if (taskList != null && !taskList.isEmpty()) {
       request.setTaskList(TaskList.newBuilder().setName(taskList).build());
@@ -264,7 +266,9 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
     if (startParameters.getInput() != null) {
       request.setInput(ByteString.copyFrom(startParameters.getInput()));
     }
-    request.setWorkflowIdReusePolicy(startParameters.getWorkflowIdReusePolicy());
+    if (startParameters.getWorkflowIdReusePolicy() != null) {
+      request.setWorkflowIdReusePolicy(startParameters.getWorkflowIdReusePolicy());
+    }
     String taskList = startParameters.getTaskList();
     if (taskList != null && !taskList.isEmpty()) {
       request.setTaskList(TaskList.newBuilder().setName(taskList).build());

--- a/src/main/java/io/temporal/internal/sync/WorkflowStubImpl.java
+++ b/src/main/java/io/temporal/internal/sync/WorkflowStubImpl.java
@@ -221,6 +221,20 @@ class WorkflowStubImpl implements WorkflowStub {
         new SignalWithStartWorkflowExecutionParameters(sp, signalName, signalInput);
     try {
       execution.set(genericClient.signalWithStartWorkflowExecution(p));
+    } catch (StatusRuntimeException e) {
+      WorkflowExecutionAlreadyStarted f =
+          StatusUtils.getFailure(e, WorkflowExecutionAlreadyStarted.class);
+      if (f != null) {
+        WorkflowExecution exe =
+            WorkflowExecution.newBuilder()
+                .setWorkflowId(sp.getWorkflowId())
+                .setRunId(f.getRunId())
+                .build();
+        execution.set(exe);
+        throw new DuplicateWorkflowException(exe, workflowType.get(), e.getMessage());
+      } else {
+        throw e;
+      }
     } catch (Exception e) {
       throw new WorkflowServiceException(execution.get(), workflowType, e);
     }

--- a/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableState.java
+++ b/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableState.java
@@ -121,4 +121,6 @@ interface TestWorkflowMutableState {
   StickyExecutionAttributes getStickyExecutionAttributes();
 
   Optional<TestWorkflowMutableState> getParent();
+
+  boolean isTerminalState();
 }

--- a/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -1309,6 +1309,12 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
         });
   }
 
+  @Override
+  public boolean isTerminalState() {
+    State workflowState = workflow.getState();
+    return isTerminalState(workflowState);
+  }
+
   private void checkCompleted() {
     State workflowState = workflow.getState();
     if (isTerminalState(workflowState)) {

--- a/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -658,7 +658,7 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
               .setNamespace(r.getNamespace())
               .setIdentity(r.getIdentity())
               .build();
-      if (mutableState != null) {
+      if (mutableState != null && !mutableState.isTerminalState()) {
         mutableState.signal(signalRequest);
         responseObserver.onNext(
             SignalWithStartWorkflowExecutionResponse.newBuilder()

--- a/src/main/java/io/temporal/worker/WorkflowImplementationOptions.java
+++ b/src/main/java/io/temporal/worker/WorkflowImplementationOptions.java
@@ -19,9 +19,9 @@
 
 package io.temporal.worker;
 
-import java.util.Objects;
-
 import static io.temporal.worker.WorkflowErrorPolicy.BlockWorkflow;
+
+import java.util.Objects;
 
 public final class WorkflowImplementationOptions {
 

--- a/src/main/java/io/temporal/workflow/WorkflowMethod.java
+++ b/src/main/java/io/temporal/workflow/WorkflowMethod.java
@@ -60,10 +60,9 @@ public @interface WorkflowMethod {
    *   AllowDuplicateFailedOnly - Allow only if workflow didn't complete successfully.
    * </ul>
    *
-   * Default is AllowDuplicateFailedOnly.
+   * Default is AllowDuplicate.
    */
-  WorkflowIdReusePolicy workflowIdReusePolicy() default
-      WorkflowIdReusePolicy.AllowDuplicateFailedOnly;
+  WorkflowIdReusePolicy workflowIdReusePolicy() default WorkflowIdReusePolicy.AllowDuplicate;
 
   /**
    * Maximum workflow execution time. Must be specified either through {@link

--- a/src/test/java/io/temporal/worker/StickyWorkerTest.java
+++ b/src/test/java/io/temporal/worker/StickyWorkerTest.java
@@ -39,6 +39,7 @@ import io.temporal.internal.metrics.MetricsTag;
 import io.temporal.internal.metrics.MetricsType;
 import io.temporal.internal.metrics.NoopScope;
 import io.temporal.internal.replay.DeciderCache;
+import io.temporal.proto.common.WorkflowIdReusePolicy;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import io.temporal.testing.TestEnvironmentOptions;
@@ -143,6 +144,7 @@ public class StickyWorkerTest {
             .setTaskList(taskListName)
             .setExecutionStartToCloseTimeout(Duration.ofDays(30))
             .setTaskStartToCloseTimeout(Duration.ofSeconds(30))
+            .setWorkflowIdReusePolicy(WorkflowIdReusePolicy.RejectDuplicate)
             .build();
     GreetingSignalWorkflow workflow =
         wrapper.getWorkflowClient().newWorkflowStub(GreetingSignalWorkflow.class, workflowOptions);
@@ -206,6 +208,7 @@ public class StickyWorkerTest {
             .setTaskList(taskListName)
             .setExecutionStartToCloseTimeout(Duration.ofDays(30))
             .setTaskStartToCloseTimeout(Duration.ofSeconds(1))
+            .setWorkflowIdReusePolicy(WorkflowIdReusePolicy.RejectDuplicate)
             .build();
 
     int count = 100;
@@ -404,6 +407,7 @@ public class StickyWorkerTest {
             .setTaskList(taskListName)
             .setExecutionStartToCloseTimeout(Duration.ofDays(30))
             .setTaskStartToCloseTimeout(Duration.ofSeconds(30))
+            .setWorkflowIdReusePolicy(WorkflowIdReusePolicy.RejectDuplicate)
             .build();
     GreetingSignalWorkflow workflow =
         wrapper.getWorkflowClient().newWorkflowStub(GreetingSignalWorkflow.class, workflowOptions);
@@ -444,6 +448,7 @@ public class StickyWorkerTest {
             .setTaskList(taskListName)
             .setExecutionStartToCloseTimeout(Duration.ofDays(30))
             .setTaskStartToCloseTimeout(Duration.ofSeconds(30))
+            .setWorkflowIdReusePolicy(WorkflowIdReusePolicy.RejectDuplicate)
             .build();
     GreetingSignalWorkflow workflow =
         wrapper.getWorkflowClient().newWorkflowStub(GreetingSignalWorkflow.class, workflowOptions);
@@ -485,6 +490,7 @@ public class StickyWorkerTest {
             .setTaskList(taskListName)
             .setExecutionStartToCloseTimeout(Duration.ofDays(30))
             .setTaskStartToCloseTimeout(Duration.ofSeconds(30))
+            .setWorkflowIdReusePolicy(WorkflowIdReusePolicy.RejectDuplicate)
             .build();
     GreetingSignalWorkflow workflow =
         wrapper.getWorkflowClient().newWorkflowStub(GreetingSignalWorkflow.class, workflowOptions);


### PR DESCRIPTION
TestService: Fixed signalWithStart failure on closed workflow even if AllowDuplicate policy is specified

Changed the default idReusePolicy to the correct service side default of (AllowDuplicate).