### PR TITLE
Move submodule to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/main/proto"]
 	path = src/main/proto
-	url = git@github.com:temporalio/temporal-proto.git
+	url = https://github.com/temporalio/temporal-proto.git


### PR DESCRIPTION
Users cannot clone and build without an ssh key due to remote being referenced via ssh url and not https. 