### PR TITLE
Removed diagnostics from exception message

### DIFF
--- a/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -378,17 +378,13 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
     completeDecisionUpdate(
         ctx -> {
           if (ctx.getInitialEventId() != historySizeFromToken + 1) {
-            StringBuilder diagnostics = new StringBuilder();
-            store.getDiagnostics(diagnostics);
             throw Status.NOT_FOUND
                 .withDescription(
                     "Expired decision: expectedHistorySize="
                         + historySizeFromToken
                         + ","
                         + " actualHistorySize="
-                        + ctx.getInitialEventId()
-                        + " history="
-                        + diagnostics)
+                        + ctx.getInitialEventId())
                 .asRuntimeException();
           }
           long decisionTaskCompletedId = ctx.getNextEventId() - 1;

--- a/src/test/java/io/temporal/workflow/WorkflowTest.java
+++ b/src/test/java/io/temporal/workflow/WorkflowTest.java
@@ -19,6 +19,9 @@
 
 package io.temporal.workflow;
 
+import static io.temporal.client.WorkflowClient.QUERY_TYPE_STACK_TRACE;
+import static org.junit.Assert.*;
+
 import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.google.common.io.CharSink;
@@ -91,21 +94,6 @@ import io.temporal.workflow.Functions.Func;
 import io.temporal.workflow.Functions.Func1;
 import io.temporal.workflowservice.v1.GetWorkflowExecutionHistoryRequest;
 import io.temporal.workflowservice.v1.GetWorkflowExecutionHistoryResponse;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
-import org.junit.rules.TestWatcher;
-import org.junit.rules.Timeout;
-import org.junit.runner.Description;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -148,9 +136,20 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
-
-import static io.temporal.client.WorkflowClient.QUERY_TYPE_STACK_TRACE;
-import static org.junit.Assert.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.rules.TestWatcher;
+import org.junit.rules.Timeout;
+import org.junit.runner.Description;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class WorkflowTest {
 


### PR DESCRIPTION
It was printing the whole workflow history on a bening exception.